### PR TITLE
chore: drop *.xcscheme gitignore rule and track Savely scheme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ Savely.xcodeproj/project.xcworkspace
 Pods
 Savely.xcworkspace/contents.xcworkspacedata
 Savely.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
-*.xcscheme
 Savely/Config.plist
 
 # Xcode user state (broader patterns)

--- a/Savely.xcodeproj/xcshareddata/xcschemes/Savely.xcscheme
+++ b/Savely.xcodeproj/xcshareddata/xcschemes/Savely.xcscheme
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1540"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1DC258032CC07DCC0002DDE3"
+               BuildableName = "Savely.app"
+               BlueprintName = "Savely"
+               ReferencedContainer = "container:Savely.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1DC258132CC07DCF0002DDE3"
+               BuildableName = "SavelyTests.xctest"
+               BlueprintName = "SavelyTests"
+               ReferencedContainer = "container:Savely.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1DC2581D2CC07DCF0002DDE3"
+               BuildableName = "SavelyUITests.xctest"
+               BlueprintName = "SavelyUITests"
+               ReferencedContainer = "container:Savely.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1DC258032CC07DCC0002DDE3"
+            BuildableName = "Savely.app"
+            BlueprintName = "Savely"
+            ReferencedContainer = "container:Savely.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1DC258032CC07DCC0002DDE3"
+            BuildableName = "Savely.app"
+            BlueprintName = "Savely"
+            ReferencedContainer = "container:Savely.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
## Summary
- Delete the `*.xcscheme` line from `.gitignore` (line 18).
- Track `Savely.xcodeproj/xcshareddata/xcschemes/Savely.xcscheme` (was silently ignored before).

## Why

Discovered while implementing Task 2 of `docs/plans/maintenance-cleanup.md`: the `*.xcscheme` rule had been globally ignoring every scheme file since the repo started. The existing `Savely.xcscheme` on disk was **never tracked** — `git ls-files | grep xcscheme` returned empty. CI's `xcodebuild -scheme Savely` worked only because xcodebuild auto-derives schemes when the file is missing.

Two consequences:
1. CI's build was non-deterministic (auto-derived scheme could drift from the developer's local one).
2. Any future shared scheme created via Xcode's "Manage Schemes → Shared" checkbox would have been silently dropped from commits — a real footgun.

Dropping the rule fixes both: the existing scheme becomes tracked verbatim, future shared schemes (e.g. `SavelyTests.xcscheme` if we ever want to run unit tests independently of UI tests) can commit naturally. User-specific scheme state continues to be excluded via `xcuserdata/` (lines 12 and 22).

This implements **Option B from the plan, with Path 2 expansion** (track scheme alongside gitignore change) since leaving the scheme untracked would reproduce the same opaque-state problem.

## What's in the scheme

Standard Xcode-generated scheme (`LastUpgradeVersion 1540`, version `1.7`):
- Build action: `Savely.app` only
- Test action: both `SavelyTests` and `SavelyUITests`, `parallelizable = YES`
- Run/Profile/Analyze/Archive: defaults pointed at `Savely`
- No hardcoded simulator UDIDs, no env vars, no command-line args, no secrets

## Test plan
- [x] `xcodebuild build -scheme Savely -destination 'platform=iOS Simulator,name=iPhone 17 Pro'` — passes
- [x] `xcodebuild test -scheme Savely -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -skip-testing:SavelyUITests` — passes
- [x] `git ls-files | grep -i xcscheme` now lists `Savely.xcodeproj/xcshareddata/xcschemes/Savely.xcscheme`
- [x] `git status` clean (only `docs/` untracked, separate concern)
- [x] `Savely/Config.plist` and `Savely/GoogleService-Info.plist` correctly stay gitignored

## Risks

Minimal. Note for reviewer:
- The Test action lists `SavelyUITests` with `skipped = NO`, but `.github/workflows/ci.yml` overrides this with `-skip-testing:SavelyUITests` (intentional per commit `33b5f5a` — template launch-perf tests flake on shared CI runners). That mismatch is by design and out of scope for this PR.
- Local builds validated on `iPhone 17 Pro` instead of `iPhone 16 Pro` (CLAUDE.md / CI default) because Xcode 26 no longer ships the 16 Pro simulator locally. CI's `macos-15` runner still has it, so CI runs unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)