### PR TITLE
refactor: clean up force-unwraps and enable lint ratchet

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -24,7 +24,7 @@ echo "🔍 Running SwiftLint on staged files…"
 # Lint only the staged files (faster than full project)
 echo "$staged_swift_files" | while read -r file; do
   if [[ -f "$file" ]]; then
-    swiftlint lint --quiet --strict --use-script-input-files <<< "$file" || {
+    swiftlint lint --quiet --strict "$file" || {
       echo ""
       echo "❌ SwiftLint failed. Fix the issues above, then re-stage and commit."
       echo "   To bypass (NOT recommended), use: git commit --no-verify"

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -90,7 +90,7 @@ force_cast:
 force_try:
   severity: error                    # error: same
 force_unwrapping:
-  severity: warning                  # warning today → bump to error after cleanup PR
+  severity: error
 
 # Custom project rules
 custom_rules:

--- a/Savely/Managers/CameraManager.swift
+++ b/Savely/Managers/CameraManager.swift
@@ -87,10 +87,11 @@ class CameraManager: NSObject, ObservableObject {
     }
 
     func setPreviewLayer(to view: UIView) {
-        previewLayer = AVCaptureVideoPreviewLayer(session: session)
-        previewLayer?.videoGravity = .resizeAspectFill
-        previewLayer?.frame = view.bounds
-        view.layer.insertSublayer(previewLayer!, at: 0)
+        let layer = AVCaptureVideoPreviewLayer(session: session)
+        layer.videoGravity = .resizeAspectFill
+        layer.frame = view.bounds
+        previewLayer = layer
+        view.layer.insertSublayer(layer, at: 0)
     }
 
     func capturePhoto() {

--- a/Savely/Models/ExpenseModel.swift
+++ b/Savely/Models/ExpenseModel.swift
@@ -29,7 +29,11 @@ extension ExpenseModel {
         print("Fetching expenses from \(startDate) to \(endDate)")
 
         // Precompute adjusted end date
-        let adjustedEndDate = Calendar.current.startOfDay(for: Calendar.current.date(byAdding: .day, value: 1, to: endDate)!)
+        guard let nextDay = Calendar.current.date(byAdding: .day, value: 1, to: endDate) else {
+            print("Error computing adjusted end date for expense fetch")
+            return []
+        }
+        let adjustedEndDate = Calendar.current.startOfDay(for: nextDay)
 
         let fetchDescriptor = FetchDescriptor<ExpenseModel>(
             predicate: #Predicate {

--- a/Savely/Models/IncomeModel.swift
+++ b/Savely/Models/IncomeModel.swift
@@ -29,7 +29,11 @@ extension IncomeModel {
         print("Fetching incomes from \(startDate) to \(endDate)")
 
         // Precompute adjusted end date
-        let adjustedEndDate = Calendar.current.startOfDay(for: Calendar.current.date(byAdding: .day, value: 1, to: endDate)!)
+        guard let nextDay = Calendar.current.date(byAdding: .day, value: 1, to: endDate) else {
+            print("Error computing adjusted end date for income fetch")
+            return []
+        }
+        let adjustedEndDate = Calendar.current.startOfDay(for: nextDay)
 
         let fetchDescriptor = FetchDescriptor<IncomeModel>(
             predicate: #Predicate {

--- a/Savely/Utilities/OpenAIClient.swift
+++ b/Savely/Utilities/OpenAIClient.swift
@@ -23,8 +23,11 @@ class OpenAIClient {
     }
 
     func fetchTip(prompt: String) async -> String? {
-        let url = URL(string: "https://api.openai.com/v1/chat/completions")!
-        
+        guard let url = URL(string: "https://api.openai.com/v1/chat/completions") else {
+            return nil
+        }
+
+
         // Construir el mensaje para el modelo
         let messages = [
             OpenAIChatMessage(role: "system", content: "Eres un asistente financiero."),

--- a/Savely/Utilities/SignInWithAppleHelper.swift
+++ b/Savely/Utilities/SignInWithAppleHelper.swift
@@ -233,6 +233,6 @@ extension SignInWithAppleHelper: ASAuthorizationControllerDelegate {
 
 extension UIViewController: ASAuthorizationControllerPresentationContextProviding {
     public func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
-        return self.view.window!
+        return self.view.window ?? ASPresentationAnchor()
     }
 }

--- a/Savely/ViewModels/Dashboard/ReportsViewModel.swift
+++ b/Savely/ViewModels/Dashboard/ReportsViewModel.swift
@@ -74,7 +74,8 @@ class ReportsViewModel: ObservableObject {
         print("Fetching weekly incomes...")
 
         let adjustedStartDate = Calendar.current.startOfDay(for: startDate)
-        let adjustedEndDate = Calendar.current.startOfDay(for: Calendar.current.date(byAdding: .day, value: 1, to: endDate)!)
+        guard let nextDay = Calendar.current.date(byAdding: .day, value: 1, to: endDate) else { return [] }
+        let adjustedEndDate = Calendar.current.startOfDay(for: nextDay)
 
         let fetchDescriptor = FetchDescriptor<IncomeModel>(
             predicate: #Predicate {
@@ -89,7 +90,8 @@ class ReportsViewModel: ObservableObject {
         print("Fetching weekly expenses...")
 
         let adjustedStartDate = Calendar.current.startOfDay(for: startDate)
-        let adjustedEndDate = Calendar.current.startOfDay(for: Calendar.current.date(byAdding: .day, value: 1, to: endDate)!)
+        guard let nextDay = Calendar.current.date(byAdding: .day, value: 1, to: endDate) else { return [] }
+        let adjustedEndDate = Calendar.current.startOfDay(for: nextDay)
 
         let fetchDescriptor = FetchDescriptor<ExpenseModel>(
             predicate: #Predicate {

--- a/Savely/ViewModels/ProfileTab/ProfileViewModel.swift
+++ b/Savely/ViewModels/ProfileTab/ProfileViewModel.swift
@@ -122,7 +122,8 @@ class ProfileViewModel: ObservableObject {
     private func fetchWeeklyIncome(from startDate: Date, to endDate: Date, in context: ModelContext) async throws -> [IncomeModel] {
         print("fetchWeeklyIncome: Fetching incomes...")
         let adjustedStartDate = Calendar.current.startOfDay(for: startDate)
-        let adjustedEndDate = Calendar.current.startOfDay(for: Calendar.current.date(byAdding: .day, value: 1, to: endDate)!)
+        guard let nextDay = Calendar.current.date(byAdding: .day, value: 1, to: endDate) else { return [] }
+        let adjustedEndDate = Calendar.current.startOfDay(for: nextDay)
 
         let fetchDescriptor = FetchDescriptor<IncomeModel>(
             predicate: #Predicate {
@@ -139,7 +140,8 @@ class ProfileViewModel: ObservableObject {
     private func fetchWeeklyExpenses(from startDate: Date, to endDate: Date, in context: ModelContext) async throws -> [ExpenseModel] {
         print("fetchWeeklyExpenses: Fetching expenses...")
         let adjustedStartDate = Calendar.current.startOfDay(for: startDate)
-        let adjustedEndDate = Calendar.current.startOfDay(for: Calendar.current.date(byAdding: .day, value: 1, to: endDate)!)
+        guard let nextDay = Calendar.current.date(byAdding: .day, value: 1, to: endDate) else { return [] }
+        let adjustedEndDate = Calendar.current.startOfDay(for: nextDay)
 
         let fetchDescriptor = FetchDescriptor<ExpenseModel>(
             predicate: #Predicate {

--- a/Savely/Views/MainNavigationView.swift
+++ b/Savely/Views/MainNavigationView.swift
@@ -656,7 +656,7 @@ struct WarmQuickDepositView: View {
 
             Button(action: saveDeposit) {
                 let goalName = selectedGoal.map { $0.name.components(separatedBy: ",").first ?? $0.name }
-                Text(goalName != nil ? "Add $\(Int(selectedPreset)) to \(goalName!)" : "Select a goal")
+                Text(goalName.map { "Add $\(Int(selectedPreset)) to \($0)" } ?? "Select a goal")
                     .font(.system(size: 15, weight: .semibold)).foregroundStyle(.white)
                     .frame(maxWidth: .infinity).frame(height: 50)
                     .background(selectedGoal != nil ? Color.warmGreen : Color.warmInkMuted)


### PR DESCRIPTION
## Summary
Closes Task 3 of `docs/plans/maintenance-cleanup.md`. Five commits:

1. `e640ab9` — services layer (CameraManager, OpenAIClient, SignInWithAppleHelper)
2. `a53346c` — fix broken pre-commit hook (discovered during Task 3 — see below)
3. `7935d15` — data models (IncomeModel, ExpenseModel)
4. `b13e472` — viewmodels + one view (ProfileViewModel, ReportsViewModel, MainNavigationView)
5. `aa1ae55` — flip `.swiftlint.yml`: `force_unwrapping` severity `warning` → `error`

After this PR, **any new `value!` from this commit forward fails CI and the local pre-commit hook**.

## Why

`swiftlint lint` was surfacing 10 `force_unwrapping` warnings on every CI run. They were warnings (not errors) so CI passed, but every new force-unwrap added to the pile silently. The "ratchet" pattern says: clean the existing violations, then bump severity to `error` so any future violation is caught at the door.

After this PR:
- `swiftlint lint --strict` reports **0 violations** across all 75 linted files.
- Local pre-commit hook now actually runs SwiftLint on staged Swift files (was structurally broken — see commit 2).
- CI's existing `swiftlint lint --reporter github-actions-logging` step (no `--strict`) keeps annotating, but the bumped severity means any new force-unwrap shows as a CI error and blocks merge.

## What each fix looks like

### Services (commit 1)
- `CameraManager.swift:93` — `previewLayer!` after just-initialized → use a local `let layer = …` and assign to the stored property at the end. Removes both the `!` and the noisy `previewLayer?.` chain.
- `OpenAIClient.swift:26` — `URL(string: literal)!` → `guard let url = … else { return nil }`. The function already returns `String?` and `nil` is the established failure path.
- `SignInWithAppleHelper.swift:236` — `self.view.window!` in `presentationAnchor(for:)` → `self.view.window ?? ASPresentationAnchor()`. The protocol can be invoked before a window is attached; a fallback anchor is the documented escape hatch.

### Data models (commit 3) and viewmodels (commit 4)
Six sites all had the same shape: `Calendar.current.date(byAdding: .day, value: 1, to: endDate)!`. All replaced with `guard let nextDay = … else { return [] }` (functions return arrays of `IncomeModel` / `ExpenseModel`, so empty array is the safe degenerate result that matches existing error paths). No shared helper extracted — duplication was 4 short lines per file, not worth a new file + pbxproj edit.

### View (commit 4)
- `MainNavigationView.swift:659` — Force-unwrap of `goalName: String?` inside a `Text(...)` ternary → `goalName.map { "Add $\(Int(selectedPreset)) to \($0)" } ?? "Select a goal"`. No new hardcoded strings introduced (both literals were already there). The `nil` branch is unreachable in practice (button is `.disabled(selectedGoal == nil)`), but the safe form documents the contract anyway.

## Out-of-scope but folded in: pre-commit hook fix (commit 2)

The `.githooks/pre-commit` script called `swiftlint lint --use-script-input-files <<< "$file"`, but `--use-script-input-files` reads from Xcode build-phase env vars (`SCRIPT_INPUT_FILE_*`), not stdin. **Every CLI `git commit` was failing with `SCRIPT_INPUT_FILE_COUNT variable not set` since PR #22** — local lint enforcement had never actually run. Fixed by passing the file as a positional argument:

```diff
-    swiftlint lint --quiet --strict --use-script-input-files <<< "$file" || {
+    swiftlint lint --quiet --strict "$file" || {
```

Verified by staging a Swift file with a known `force_unwrapping` warning — the hook caught it. Folded into this PR (rather than a separate one) because the entire point of Task 3 is "make lint enforcement actually work end-to-end" and the hook was the broken local half of that.

## Test plan
- [x] `swiftlint lint --strict` — 0 violations across 75 files
- [x] `xcodebuild build -scheme Savely -destination 'platform=iOS Simulator,name=iPhone 17 Pro'` — passes
- [x] `xcodebuild test -scheme Savely -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -skip-testing:SavelyUITests` — passes
- [x] Pre-commit hook verified working (caught known `force_unwrapping` on staged file)
- [x] No new hardcoded user-facing strings
- [x] No secrets staged

## Risks

- The 6 sites that returned `[]` on calendar-failure now degrade silently instead of crashing. If you ever want to surface this as a UI error, those would be the spots to add an error state — but a calendar arithmetic failure on `+1 day` is essentially impossible in practice, so silent degradation matches the prior implicit behavior more honestly than a crash did.
- `MainNavigationView.swift:659` change uses `Optional.map(...) ?? default` instead of an `if let`/`else` view-builder split. Functionally identical but slightly less SwiftUI-idiomatic — flag if you'd rather see the explicit form.
- After this merges, any new force-unwrap from any future PR will fail SwiftLint locally (pre-commit hook) and on CI. Intentional. If you ever need a true invariant unwrap, use `guard let x = value else { fatalError("invariant violated: …") }` — explicit failure mode, satisfies the linter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)