### PR TITLE
docs: executable implementation plans for PRs A/B/C

### DIFF
--- a/docs/plans/money-surfaces-audit.md
+++ b/docs/plans/money-surfaces-audit.md
@@ -73,6 +73,12 @@ English-only); ReportsView's charts group by raw free text, making the
 
 ## Recommended roadmap (3 PRs, in this order)
 
+> Executable implementation plans (self-contained, written for a fresh
+> session with no shared context):
+> [PR A](pr-a-honesty-correctness.md) ·
+> [PR B](pr-b-real-categories.md) ·
+> [PR C](pr-c-goals-complete.md)
+
 ### PR A — Honesty & correctness (fix what lies or corrupts)
 1. **Remove the favorite-goal coupling** (finding #1) — deposits become
    the only mutation path. Regression test for the double-count.
@@ -87,9 +93,9 @@ English-only); ReportsView's charts group by raw free text, making the
 `category: String?` on ExpenseModel + `source: String?` on IncomeModel
 (additive migration). Persist the chips that already exist; list falls
 back to keyword inference for legacy rows. Unblocks per-source income
-breakdown, meaningful category charts, future budgets. Consider
-resurfacing ReportsView (reachable from Money tab) once its charts mean
-something.
+breakdown, meaningful category charts, future budgets. ReportsView gets
+resurrected with a Profile entry point once its charts mean something
+(decision in the PR B plan).
 
 ### PR C — Goals, completed (the biggest CRUD hole + deposit ledger)
 1. **Goal edit sheet** wired to both dead pencils (name/target/deadline/

--- a/docs/plans/pr-a-honesty-correctness.md
+++ b/docs/plans/pr-a-honesty-correctness.md
@@ -1,0 +1,202 @@
+# PR A — Honesty & correctness
+
+**Source audit:** `docs/plans/money-surfaces-audit.md` (2026-08-15)
+**Branch:** `fix/money-surfaces-honesty` off `dev`, PR back to `dev` (the developer merges manually — never merge yourself)
+**Complexity:** Medium. Pure Swift edits + 5 file deletions; one small behavioral removal with a regression risk that task 1 covers.
+
+> **Execute the tasks in order.** Every design decision here is already
+> made and approved by the owner — do not re-litigate, do not widen scope.
+> Read `CLAUDE.md` and `.claude/knowledge/gotchas.yaml` first; the
+> **Repo traps** section at the bottom of this file covers what they don't.
+
+## Context (self-contained)
+
+Savely is a local-first SwiftUI + SwiftData iOS app (iOS 26+, no accounts,
+no backend). A five-surface code audit found correctness bugs in the
+income/expense/goals flows. This PR fixes everything that **lies or
+corrupts data** without adding features. Money model stays `Double` for
+now (cents migration is explicitly deferred — do not touch it).
+
+## Tasks
+
+### 1. Remove the hidden favorite-goal coupling (CRITICAL)
+
+Every logged income/expense silently mutates the favorite goal's
+`current`: income adds the FULL amount, expense subtracts it, via
+NotificationCenter handlers in `GoalsViewModel` (registration ~
+`GoalsViewModel.swift:160-183`, mutation `updateFavoriteGoalProgress`
+~`:199-219`). This **double-counts** with the payday auto-move shipped in
+PR #33 (`AutoMoveSuggestion.apply()` already adds `autoMoveAmount` on
+income save), fires only if the Goals tab was ever opened, and lets
+history edits distort savings.
+
+- **Delete** `updateFavoriteGoalProgress` and the `.incomeAdded` /
+  `.expenseAdded` / `.incomeDeleted` / `.expenseDeleted` observer
+  registrations + handler methods in `GoalsViewModel`.
+- **Keep the NotificationCenter posts** in
+  `ExpensesTrackerViewModel.swift:62,83` and
+  `IncomesTrackerViewModel.swift:99` (+ its delete post) — task 2 reuses
+  them for list refresh.
+- After this task, the ONLY code paths that mutate `GoalModel.current`
+  must be the three deposit flows (`GoalDetailView.swift:236-242`,
+  `DashboardView.swift:385-390`, `MainNavigationView.swift` quick-deposit
+  `saveDeposit`) and `AutoMoveSuggestion.apply()`.
+- **Validate:** `grep -rn "updateFavoriteGoalProgress\|incomeAdded\|expenseAdded" Savely/` —
+  posts remain, goal-mutating observers gone. Then in the simulator:
+  create a goal (favorite), log a $500 income with auto-move armed at
+  $100 → goal rises by exactly $100, not $600; log an expense → goal
+  unchanged.
+
+### 2. Fix stale lists (movements logged via "+" never appear)
+
+The Money tab's view models hold manual fetch arrays and refetch only
+when `modelContext == nil` on appear; the global "+" sheets write through
+their **own** VM instances (`MainNavigationView.swift:350, 441`), so new
+movements are invisible until app relaunch (`MoneyView.swift:19-22` keeps
+both sub-views alive in a ZStack, so `onAppear` never refires).
+
+- In `ExpensesTrackerViewModel` and `IncomesTrackerViewModel`: subscribe
+  (in `init` or `setModelContext`) to the already-posted notifications
+  (`.expenseAdded`/`.expenseDeleted`, `.incomeAdded`/`.incomeDeleted`)
+  and call the existing `fetchExpenses()`/`fetchIncomes()`. Remove
+  observers in `deinit`.
+- Also make `onAppear` refetch unconditionally
+  (`ExpenseTrackerView.swift:178`, `IncomesTrackerView.swift:156`) —
+  belt and suspenders.
+- Do NOT convert these views to `@Query` in this PR (bigger refactor,
+  separate risk).
+- **Validate (simulator):** log an expense and an income via the global
+  "+" sheet → switch to Money tab → both appear immediately, chart and
+  monthly total update, no relaunch.
+
+### 3. Truthful headers
+
+- `ExpenseTrackerView.swift:48` — replace the hardcoded `"April"` with
+  the current month (`DateFormatter` with `"MMMM"` format, or
+  `Date().formatted(.dateTime.month(.wide))`).
+- `ExpenseTrackerView.swift:184-188` — `formattedTotal` currently sums
+  ALL expenses ever; filter to the current calendar month
+  (`Calendar.current.isDate($0.date, equalTo: Date(), toGranularity: .month)`)
+  so the label and the number agree.
+- `IncomesTrackerView.swift:34` — same `"April"` fix (its amount is
+  already monthly; only the label lies).
+- **Validate (simulator):** both headers show the actual current month;
+  add an expense dated today → expenses header total equals just that
+  amount even if legacy all-time data exists.
+
+### 4. Input honesty (silent failures + es-MX decimals)
+
+- `ExpensesTrackerViewModel.addExpense` (`:48-73`) and
+  `IncomesTrackerViewModel.addIncome` (`:85-110`) parse with
+  `Double(amount)` and silently no-op on failure. (Note: es_MX uses "."
+  as decimal separator, so it is NOT the broken case — comma-decimal
+  locales like es_ES/fr_FR/de_DE are.) Create ONE shared helper —
+  `Savely/Utilities/AmountParsing.swift` with
+  `parseAmount(_ raw: String) -> Double?` that **accepts both separators
+  regardless of locale** (the in-app keypad hardcodes "."): try
+  `Double(raw)` first, then retry with "," replaced by "." when the
+  string contains exactly one comma and no period. Reject empty,
+  non-numeric, and `<= 0` results. On `nil`: set the VM's
+  `errorMessage`/`showError` instead of silently returning.
+- `IncomesTrackerView` has NO `.alert` at all — add one bound to
+  `viewModel.showError`, mirroring `ExpenseTrackerView.swift:179-181`.
+- Show the negative income trend: drop the `> 0` guard at
+  `IncomesTrackerView.swift:50` and color the badge by sign (green up /
+  `warmClay` down). A finance app hiding bad news undermines trust.
+- **Validate:** unit-test `parseAmount` with explicit expectations:
+  `"1234.56"` → 1234.56 · `"1234,56"` → 1234.56 · `"12,34,56"` → nil ·
+  `""` → nil · `"abc"` → nil · `"0"` → nil (rejected as non-positive).
+  Simulator: entering garbage in the inline add shows an alert instead
+  of nothing.
+
+### 5. One-line resurrections
+
+- `ProfileView.swift:126` — the "Weekly PDF report" row's `onTap: {}` is
+  the ONLY reachable entry to a fully working PDF pipeline. Wire it to
+  `viewModel.generateWeeklyReportPDF()` (the VM's `modelContext` is set
+  at `ProfileView.swift:148`; the `.alert` for its error path already
+  exists at `:142-144`).
+- `DashboardView.swift:99-101` — "See all" next to Recent is inert. Give
+  `DashboardView` an `var onSeeAll: () -> Void = {}` and have
+  `MainNavigationView` (tab creation at `:20-25`) pass a closure that
+  switches the selected tab to Money.
+- **Validate (simulator):** with a few movements logged this week,
+  tapping "Weekly PDF report" opens the share sheet with a PDF; "See
+  all" lands on the Money tab.
+
+### 6. Remove dead affordances and dead files
+
+Controls that render but do nothing — **remove them** (do not implement):
+
+- Search button `ExpenseTrackerView.swift:53` (empty closure).
+- Expense row `chevron.right` `ExpenseTrackerView.swift:218` (no action).
+- HeroGoalCard chevron-in-a-box `DashboardView.swift:185-190` (plain
+  Image implying navigation that does not exist; PR C wires the card's
+  pencil to an edit sheet instead — the chevron stays gone).
+- "Tip: long-press + to repeat your last action" line
+  `MainNavigationView.swift:254-256` (no such gesture exists).
+
+Dead files — **delete** (each needs its pbxproj references removed too;
+see Repo traps):
+
+- `Savely/Views/DashboardTab/AddExpenseView.swift` (unreferenced; would
+  crash if presented — missing environment object).
+- `Savely/Views/DashboardTab/AddIncomeView.swift` (unreferenced legacy,
+  off-design-system).
+- `Savely/Views/IncomesView.swift` ("Hello, World!" scaffold).
+- `Savely/Views/DashboardTab/AddGoalView.swift` (unreferenced legacy).
+- `Savely/Views/ProfileTab/WeeklyInsightsView.swift` (orphaned; its PDF
+  row is superseded by task 5; also delete the now-unused
+  `newTipsCount` placeholder in `ProfileViewModel.swift:39-43`).
+- Leave `ReportsView.swift` in place — PR B resurrects it.
+
+- **Validate:** `grep -rn "AddExpenseView\|AddIncomeView(\|IncomesView(\|AddGoalView\|WeeklyInsightsView\|newTipsCount" Savely/` → no hits;
+  `plutil -lint Savely.xcodeproj/project.pbxproj` OK; full build green.
+
+## Acceptance (all must pass before opening the PR)
+
+- [ ] `xcodebuild build` + `xcodebuild test -skip-testing:SavelyUITests` green (see Repo traps for destination)
+- [ ] `swiftlint lint --strict` → 0 violations
+- [ ] Simulator walk-through: the four Validate scenarios above, then **uninstall the app** (test-data cleanup is a house rule)
+- [ ] `Localizable.xcstrings` staleness churn from deleted files is committed (Xcode marks keys stale on build — expected, include it)
+- [ ] Conventional commits, no AI attribution, PR to `dev`, wait for CI green, do NOT merge
+
+## String policy (decision)
+
+New user-facing strings in this PR (alerts, month header) **match the
+surrounding warm-redesign views: literal strings**, relying on the String
+Catalog auto-extraction. Do NOT refactor existing literals into
+`Strings.swift` here — that cleanup is deliberately out of scope despite
+CLAUDE.md's general rule; note it in the PR description.
+
+## Out of scope (do not touch)
+
+Category/source fields (PR B) · goal editing, deposit ledger, pace math,
+wizard fixes (PR C) · Double→cents migration (deferred) · any `@Query`
+rewrite of the tracker VMs.
+
+## Repo traps (read before writing code)
+
+1. **pbxproj uses explicit file references** — no synchronized groups.
+   Deleting a file requires removing its 4 line-entries (PBXBuildFile,
+   PBXFileReference, group child, Sources-phase entry). A safe recipe
+   used successfully in this repo: filter every pbxproj line containing
+   the filename with a small python script, then `plutil -lint` the
+   result. Adding files similarly requires generating a 24-hex ID and
+   inserting all 4 entries (group IDs: Utilities
+   `1D88B7D62CC9FA28009B6538`, Views/Components
+   `1DC258402CC61D250002DDE3`, Models `1DC258472CC629120002DDE3`,
+   SavelyTests `1DC258172CC07DCF0002DDE3`; app Sources-phase anchor line:
+   `/* SplashScreenView.swift in Sources */,`).
+2. **commit-msg hook** enforces Conventional Commits with subject
+   **≤ 72 chars after the `type: ` prefix** — long subjects are rejected.
+3. **SwiftLint ratchet:** `force_unwrapping`/`force_cast`/`force_try`
+   are `error`. In tests use `try XCTUnwrap(...)`, never `!`. The
+   pre-commit hook lints staged files.
+4. **Tests are XCTest** (not Swift Testing). New test files must be
+   registered in the SavelyTests target in pbxproj.
+5. **Simulator name drifts** — pick from
+   `xcrun simctl list devices available` (currently `iPhone 17 Pro`
+   locally); never hardcode in CI (CI already picks dynamically).
+6. `try? modelContext.save()` is the codebase's (bad) habit — for NEW
+   code, use do/catch with the VM's error surface.

--- a/docs/plans/pr-b-real-categories.md
+++ b/docs/plans/pr-b-real-categories.md
@@ -1,0 +1,147 @@
+# PR B — Real categories & sources
+
+**Source audit:** `docs/plans/money-surfaces-audit.md` (2026-08-15)
+**Depends on:** PR A merged (stale-list fixes and honest headers land first).
+**Branch:** `feat/real-categories` off `dev`, PR back to `dev` (developer merges manually)
+**Complexity:** Medium. One additive model migration + persistence wiring + display fallback + ReportsView resurrection.
+
+> Decisions below are made — do not re-litigate. Read `CLAUDE.md`,
+> `.claude/knowledge/gotchas.yaml`, and the **Repo traps** section of
+> `docs/plans/pr-a-honesty-correctness.md` (same traps apply, especially
+> the pbxproj procedure for any new file).
+
+## Context (self-contained)
+
+Categorization is currently fake at every layer: `ExpenseModel` and
+`IncomeModel` have no category/source field; the quick-add sheets collect
+chips and discard them; the Money tab re-infers "categories" by matching
+English keywords against the description string; ReportsView's charts
+group by raw free text. This PR makes categorization real with the
+smallest possible model change.
+
+## Design decisions (fixed)
+
+- **Plain optional strings, not entities:** `category: String?` on
+  `ExpenseModel`, `source: String?` on `IncomeModel`. Additive with `nil`
+  default → SwiftData lightweight migration is automatic. No Category
+  entity/table — YAGNI until budgets exist.
+- **Canonical values = the chips that already exist in the UI:**
+  expenses `Coffee / Food / Transit / Shopping / Other`
+  (`MainNavigationView.swift:335-341`), incomes
+  `Paycheck / Freelance / Gift / Other` (`sources` array,
+  `MainNavigationView.swift:443`).
+  Store the chip string as-is.
+- **Legacy rows:** display falls back to the existing keyword inference
+  when `category == nil`. Never backfill-write inferred values into the
+  store (inference is a guess; the store holds only user-chosen truth).
+- **Description and category are independent** — picking "Shopping" and
+  typing "Zara" stores both; the chip is no longer a description
+  fallback.
+
+> Line numbers below were verified against `dev` **before PR A merges**;
+> PR A shifts some of these files by a few lines. Treat citations as
+> symbol anchors (search for the identifier), not absolute offsets.
+
+## Tasks
+
+### 1. Model fields + migration
+
+- `ExpenseModel.swift`: add `var category: String?` (+ init param,
+  default `nil`). `IncomeModel.swift`: add `var source: String?` (same).
+- **Validate:** app upgrades in-place in the simulator over a store that
+  already has data (install current `dev` build, add rows, then install
+  this branch's build — data survives, fields read as nil).
+
+### 2. Persist the chips at the write paths
+
+- `WarmQuickExpenseView` (`MainNavigationView.swift:~343-426`): pass
+  `selectedCat` through to the insert. Today `:423` folds the chip into
+  the description only when the description is empty — replace that:
+  description = typed text (or chip label if empty, unchanged), AND
+  `category = selectedCat` always.
+- `WarmQuickIncomeView` (`:~430-585`): same for `selectedSource` at
+  `:576` — keep the description fallback behavior, and additionally
+  store `source = selectedSource` always.
+- `ExpensesTrackerViewModel.addExpense` / `IncomesTrackerViewModel.addIncome`:
+  add optional `category:`/`source:` parameters (default `nil`) so the
+  inline tab forms keep compiling; thread them into the model insert.
+- Receipt scanner (`CameraViewModel.confirmTotal` ~`:163-169`):
+  **decision — leave `category` as `nil`** for scanned expenses (display
+  falls back to inference); scanner improvements are out of scope.
+- **Validate:** add expense "Zara" + chip "Shopping" via quick-add →
+  Money tab row shows Shopping icon/label (not keyword guess); same for
+  income source.
+
+### 3. Display uses stored truth, inference as fallback
+
+- `ExpenseTrackerView.swift:230-257` (`categoryLabel` + icon/color
+  mapping): if the row's `expense.category` is non-nil use it directly;
+  else run the existing keyword inference (rename it
+  `legacyInferredCategory` so intent is explicit).
+- Fixed icon/tile mapping for the five canonical chips (the existing
+  switches have no branches for "Food"/"Shopping"/"Other" — use these,
+  matching the Warm Meadow pairings already used for badges):
+
+  | Chip | SF Symbol | Tile bg / icon color |
+  |---|---|---|
+  | Coffee | `cup.and.saucer.fill` | warmAmberSoft / warmAmber |
+  | Food | `fork.knife` | warmGreenSoft / warmGreen |
+  | Transit | `car.fill` | warmSkySoft / warmSky |
+  | Shopping | `bag.fill` | warmClaySoft / warmClay |
+  | Other | `creditcard` | warmBg / warmInkMuted |
+- Income history rows (`IncomesTrackerView.swift` list ~`:136-200`): show
+  a small source tag/icon when `source != nil` (match Warm Meadow: soft
+  tile + label, look at how expense rows do it).
+- **Validate (simulator):** legacy rows (nil) still show inferred
+  labels; new rows show the chosen chip even when the description
+  contains a misleading keyword (e.g. description "coffee mug gift",
+  category "Shopping" → shows Shopping).
+
+### 4. Resurrect ReportsView (charts become meaningful)
+
+`ReportsView.swift` works but is orphaned, and its `SectorMark` pie
+groups by description free-text. With real categories:
+
+- Group the expense distribution chart by `category ?? legacy inference`
+  instead of raw description (`ReportsView.swift:76-83`).
+- Fix the init anti-pattern at `ReportsView.swift:17` (reading
+  `Environment(\.modelContext).wrappedValue` inside `init`) — rely on
+  the existing `onAppear` `setModelContext` (`:100`) only.
+- **Entry point (decision):** a "Reports" `SettingsNavRow` in
+  ProfileView's Settings section (below "Weekly PDF report"), pushing
+  `ReportsView` via `navigationDestination` — ProfileView already has
+  the NavigationStack + the pattern (see `showingAchievements`).
+- **Validate (simulator):** Profile → Reports opens; charts render from
+  real data; category pie shows chip-named slices.
+
+### 5. Tests
+
+XCTest, registered in the SavelyTests target (pbxproj procedure in PR A's
+Repo traps). Suggested file: `SavelyTests/CategoryPersistenceTests.swift`
+using an in-memory `ModelContainer`
+(`ModelConfiguration(isStoredInMemoryOnly: true)`):
+
+- Expense round-trips `category`; income round-trips `source`; both nil
+  by default.
+- The display fallback helper: stored category wins over a description
+  full of contradicting keywords; nil falls back to inference; unknown
+  text infers the generic label.
+
+## String policy (decision)
+
+New user-facing strings (source tags, "Reports" row, chart labels) match
+the surrounding warm views: **literal strings**, String Catalog
+auto-extraction. No `Strings.swift` refactor in this PR.
+
+## Acceptance
+
+- [ ] Build + tests green, `swiftlint lint --strict` clean (local gate before push)
+- [ ] In-place upgrade over existing data verified in the simulator (no store reset)
+- [ ] Quick-add chips persist; legacy rows unchanged visually
+- [ ] Reports reachable from Profile with category-grouped charts
+- [ ] Simulator test data cleaned (uninstall) · conventional commits, subject ≤72 chars, no AI attribution · PR to `dev`, CI green, do NOT merge
+
+## Out of scope
+
+Budgets, category management/custom categories, scanner category
+detection, cents migration, goal work (PR C).

--- a/docs/plans/pr-c-goals-complete.md
+++ b/docs/plans/pr-c-goals-complete.md
@@ -1,0 +1,190 @@
+# PR C — Goals, completed: edit sheet, deposit ledger, real pace
+
+**Source audit:** `docs/plans/money-surfaces-audit.md` (2026-08-15)
+**Depends on:** PR A merged (the favorite-goal coupling must already be
+dead — this PR assumes deposits are the only mutation path). Independent
+of PR B.
+**Branch:** `feat/goals-complete` off `dev`, PR back to `dev` (developer merges manually)
+**Complexity:** Large. New model entity + one new sheet + three flows
+touched + math replacement. Split into the 4 commits suggested below.
+
+> Decisions are made — do not re-litigate. Read `CLAUDE.md`,
+> `.claude/knowledge/gotchas.yaml`, and the **Repo traps** section of
+> `docs/plans/pr-a-honesty-correctness.md` (pbxproj procedure, commit
+> hook, XCTest, SwiftLint ratchet).
+
+## Context (self-contained)
+
+Goals can be created (4-step wizard) and deleted, but **nothing can be
+edited afterward** — both edit pencils are empty closures. Deposits
+mutate `GoalModel.current` in place with no record: notes are collected
+and discarded, history is unrepresentable, and the payday auto-move's
+month-margin math (PR #33, `AutoMoveSuggestion`) cannot subtract money
+already moved to goals this month. Goal detail fakes its stats ("Per
+week" divides by a hardcoded 24; ETA is circular; dashboard PACE always
+says "On track") even though `deadline` is persisted.
+
+## Design decisions (fixed)
+
+- **`DepositModel`** (new `@Model`, file `Savely/Models/DepositModel.swift`):
+  `id: UUID`, `goalID: UUID`, `amount: Double`, `date: Date`,
+  `note: String?`, `source: String` (`"manual"` or `"auto-move"`).
+  Registered in the container list at `SavelyApp.swift:26` (additive —
+  new entity, lightweight migration automatic).
+- **One write path:** a small helper (suggestion:
+  `Savely/Utilities/GoalDeposits.swift`) with
+  `record(goal:amount:note:source:context:)` that (a) clamps and mutates
+  `goal.current` exactly like today (`min(current + amount, target)`),
+  (b) inserts the `DepositModel`, (c) saves with do/catch. All four
+  writers use it: `GoalDetailView.swift:236-242`,
+  `DashboardView.swift:385-390`, quick-deposit `saveDeposit` in
+  `MainNavigationView.swift:~734-739`, and the auto-move apply path in
+  `WarmQuickIncomeView.saveAndDismiss` (replace the bare
+  `suggestion.apply()` call with `GoalDeposits.record(..., source:
+  "auto-move")`). **Delete `AutoMoveSuggestion.apply()`** and migrate its
+  two tests (`AutoMoveSuggestionTests.testApplyClampsAtTarget` and
+  `testApplyAddsAmount`, `SavelyTests/AutoMoveSuggestionTests.swift:~89-99`)
+  into `GoalDepositsTests` as clamp tests of `record(...)`. Note: the
+  "defaults keep existing tests valid" guarantee applies to the
+  `compute` signature change only — the apply-tests MUST be migrated or
+  the suite breaks.
+- **Month margin correction:** `AutoMoveSuggestion.compute` gains
+  `monthDepositTotal: Double = 0`, subtracted in the margin:
+  `margin = monthIncomeTotal + incomeAmount − monthExpenseTotal − monthDepositTotal`.
+  `WarmQuickIncomeView` passes the current-month sum from a `@Query` of
+  deposits. Default `0` keeps existing tests valid.
+- **Pace policy (used by GoalDetailView stats + HeroGoalCard PACE):**
+  - `requiredWeeklyPace = remaining ÷ weeks-to-deadline` (same math as
+    `AutoMoveSuggestion.compute`'s inner function — extract it into the
+    new helper file so there is exactly one implementation).
+  - `actualWeeklyPace` = average of the goal's deposits over the last 4
+    weeks; if the goal has no deposits yet, fall back to
+    `autoMoveAmount / 4.33` (its configured monthly pace as weekly).
+  - On track ⇔ no deadline, or `actualWeeklyPace >= requiredWeeklyPace`.
+  - ETA = `remaining ÷ actualWeeklyPace` weeks from today (cap display
+    at "1+ year"); if pace is 0, show "—" (never fake a date).
+- **No date option (do it exactly this way):** keep
+  `AddGoalState.deadline: Date` NON-optional, and add
+  `@Published var hasDeadline: Bool = true`. The "No date" preset
+  (`AddGoalFlow.swift:441-443`) sets `hasDeadline = false` (today it
+  silently keeps a stale 18-month default); picking any date or duration
+  preset sets it back to `true`. `plantGoal` persists
+  `deadline: state.hasDeadline ? state.deadline : nil`. This avoids
+  optional plumbing through `MiniCalendarView` (whose binding is a
+  non-optional `Date`, `AddGoalFlow.swift:504-505`). When
+  `hasDeadline == false`: Step 3's pace card and `formattedDeadline`
+  (`:419, :495-498`) show "—", Step 4's `formattedDeadline`/
+  `shortDeadline`/"Goal · deadline"/"By" tile (`:707-712, :608, :638`)
+  show "No date"/"—", the calendar keeps rendering its current selection
+  (visually deemphasized is fine, no behavior change needed), and
+  `plantGoal`'s `autoMoveAmount: state.monthlyPace.rounded()` falls back
+  to `0` (pace is undefined without a deadline; the user can set the
+  amount later in the edit sheet from Commit 2).
+
+## Tasks (suggested commit boundaries)
+
+### Commit 1 — Deposit ledger
+
+1. `DepositModel.swift` (+ pbxproj registration, Models group
+   `1DC258472CC629120002DDE3`; container list `SavelyApp.swift:26`).
+2. `GoalDeposits.record(...)` helper; migrate the four write paths to it.
+   The deposit NOTE fields (`GoalDetailView.swift:149,199-211`,
+   `DashboardView.swift:301,349-361`) finally persist — pass them through.
+3. `AutoMoveSuggestion`: add `monthDepositTotal` param + margin change;
+   `WarmQuickIncomeView` supplies it via `@Query` deposits summed for the
+   current month.
+4. GoalDetailView: deposits history section (query by `goalID`, date
+   desc; Warm Meadow list rows: amount, relative date, note, small
+   "auto" tag when `source == "auto-move"`).
+5. Tests (`SavelyTests/GoalDepositsTests.swift`, in-memory container):
+   record() clamps at target and inserts the entity; margin math
+   subtracts deposits (extend `AutoMoveSuggestionTests` — defaults keep
+   old cases green).
+
+### Commit 2 — Goal edit sheet
+
+1. New `Savely/Views/GoalsTab/GoalEditSheet.swift` (pbxproj group:
+   `1DC014012CDE00DB009A46E1` — the **Views**/GoalsTab group, the one
+   whose children include GoalDetailView.swift and AddGoalFlow.swift.
+   CAUTION: a grep for `/* GoalsTab */` returns TWO groups; the other,
+   `1DAF5D192CEDC103001C0AF3`, is ViewModels/GoalsTab — registering the
+   file there makes the build fail with "Build input file cannot be
+   found").
+   Fields: name, target, color (expose **all 13** `GoalColor` cases —
+   the wizard only shows 6), deadline (optional, with a "no date"
+   clear), auto-move toggle + amount. Validation: name non-empty,
+   `target > 0`, `target >= current` (shrinking below saved money is
+   confusing — reject with a clear message), deadline nil-or-future.
+   One explicit Save button; do/catch around save with visible error.
+2. Wire BOTH dead pencils to it: `GoalDetailView.swift:82` and
+   `DashboardView.swift:261` (HeroGoalCard — present as a sheet).
+3. Star behavior: make `setFavorite` a toggle (currently re-favorites,
+   `GoalsViewModel.swift:118-139`) — tapping the current favorite's star
+   unfavorites it.
+4. Tests: validation matrix for the sheet's rules (pure helper if
+   extracted, else skip UI-only paths).
+
+### Commit 3 — Real pace, ETA, completion
+
+1. Extract the weeks/pace math into the helper (single implementation;
+   `AutoMoveSuggestion` consumes it too).
+2. `GoalDetailView.swift:95-108`: replace `/24` "Per week" and circular
+   ETA with the pace policy above; also display the deadline (persisted
+   since PR #33 but shown nowhere).
+3. `DashboardView.swift:281-283` + `GoalsView.swift:282-284`: PACE label
+   from the policy ("On track" / "Behind" / "Complete!"), never
+   hardcoded.
+4. Completion: when `current >= target`, GoalsView shows the goal in a
+   "Completed" section (out of the active count at `GoalsView.swift`
+   header) with a one-time celebration pop on the card — reuse the
+   high-damping spring + glow pattern from `AchievementRow`
+   (`AchievementsView.swift`), gate one-time via UserDefaults set of
+   celebrated goal IDs (mirror `AchievementStore`), respect
+   `accessibilityReduceMotion` (instant, no pop).
+5. Tests: pace policy (required vs actual, no-deadline, zero-pace ETA).
+
+### Commit 4 — Wizard traps
+
+1. "No date" → `deadline: Date?` = nil (decision above),
+   `AddGoalFlow.swift:441-443` + state type change + pace fallbacks.
+2. "Plant goal" silent no-op (`AddGoalFlow.swift:65-66`): disable the
+   button when name is empty or amount <= 0 instead of guard-return.
+3. Success screen "Add a deposit" (`AddGoalFlow.swift:41-45,788-796`):
+   store the created `GoalModel` in `@State` on `AddGoalFlowView`
+   (`plantGoal` currently drops the reference, `:65-80`), and present
+   `DepositSheet(goal:modelContext:)` — the self-contained sheet defined
+   in `DashboardView.swift` — over the success screen. Do NOT route
+   through `WarmQuickDepositView`/`QuickAddScreen` (needless plumbing).
+4. Step-4 Skip empty closure (`AddGoalFlow.swift:588`): make it advance
+   (same as Next without changes) or remove the button.
+5. Emoji picker + Reminders toggle (collected, never persisted): neither
+   is a step — the emoji picker is the SYMBOL section inside Step 1
+   (`AddGoalFlow.swift:212-234`) and the Reminders toggle is a recap row
+   inside Step 4 (`:661`). **Remove that section and that row**; the
+   wizard stays 4 steps, dots/`AddGoalHeader(step:total:)` unchanged.
+   Delete `AddGoalState.emoji` and `showReminders`, and replace the emoji
+   in its three render spots (Step 1 live preview `:165`, Step 2 chip
+   `:299`, Step 4 hero card `:603`) with the goal-name initial on the
+   color circle — the pattern `WarmGoalCard`/`WarmQuickDepositView`
+   already use. Do not add model fields (YAGNI; reminders belong to a
+   future notifications pass).
+
+## String policy (decision)
+
+New user-facing strings (edit sheet labels, deposit history, "Completed"
+section, pace/ETA labels) match the surrounding warm views: **literal
+strings**, String Catalog auto-extraction. No `Strings.swift` refactor in
+this PR.
+
+## Acceptance
+
+- [ ] Full gate green locally (build, tests incl. new suites, `swiftlint lint --strict`)
+- [ ] Simulator end-to-end: create goal (with and without date) → edit it (name/target/color/deadline/auto-move) → deposit with a note from all three flows → history shows all deposits with the auto tag after an armed auto-move income → PACE/ETA react to deadline changes → complete a goal → celebration once, listed under Completed
+- [ ] Armed auto-move income: goal rises by exactly the suggestion amount; a second income the same month sees a margin reduced by the first deposit
+- [ ] In-place upgrade over existing data (no store reset)
+- [ ] Test data cleaned (uninstall) · conventional commits ≤72-char subjects, no AI attribution · PR to `dev`, CI green, do NOT merge
+
+## Out of scope
+
+Budgets · quick-deposit custom amount keypad · notifications/reminders ·
+cents migration · `ReportsView` concerns (PR B).


### PR DESCRIPTION
## Summary

The three money-surfaces plans from `docs/plans/money-surfaces-audit.md`, written to be executed by a **separate model session with zero shared context**:

- **[PR A — Honesty & correctness](docs/plans/pr-a-honesty-correctness.md)**: the CRITICAL favorite-goal coupling (double-counts with auto-move), stale lists, lying headers, silent input failures, the 1-line PDF resurrection, dead affordances + 5 dead files. Carries the **Repo traps** section (pbxproj procedure with verified group IDs, 72-char commit hook, SwiftLint ratchet, XCTest, simulator drift) that the other two plans reference.
- **[PR B — Real categories](docs/plans/pr-b-real-categories.md)**: `category`/`source` optional fields, chip persistence, inference-as-fallback with a fixed icon/tile table, ReportsView resurrected via Profile.
- **[PR C — Goals complete](docs/plans/pr-c-goals-complete.md)**: deposit ledger (`DepositModel`, single write path, auto-move margin correction), goal edit sheet on both dead pencils, real pace/ETA policy, completion state, wizard traps. Split into 4 suggested commits.

**Independently reviewed before this PR**: a verification agent spot-checked ~30 file:line citations against the code, verified every load-bearing claim (notification observers, PDF wiring, `apply()` call sites, wizard structure, pbxproj IDs), and empirically tested the locale claim. Its 5 must-fix findings are incorporated — notably: es_MX uses "." as decimal separator (my original comma-decimal premise was wrong; parse expectations now explicit), `hasDeadline: Bool` instead of optional-`Date` plumbing through `MiniCalendarView`, and the correct Views/GoalsTab pbxproj group ID called out explicitly (a naive grep returns two ambiguous groups).

Execution order: **A → B → C** (A blocks both; B and C are independent of each other).