### PR TITLE
docs: product/design context and plans for PRs D, D2, D3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,17 @@ The orchestrator (`.claude/protocols/orchestrator.md`) handles full classificati
 
 ---
 
+## Design context
+
+- `PRODUCT.md` — who Savely is for, brand personality (Warm · Patient ·
+  Discreet), anti-references, design principles, and the **WCAG AA
+  whole-app** commitment. Read before any UI work.
+- `DESIGN.md` — the Warm Meadow visual system as it exists today (tokens
+  in the frontmatter are normative). New UI must match it; do not restyle.
+- Roadmap for the profile / dark mode / accessibility work:
+  `docs/plans/pr-d-profile.md` → `pr-d2-adaptive-palette.md` →
+  `pr-d3-accessibility.md`.
+
 ## Pointers
 
 - Orchestrator: `.claude/protocols/orchestrator.md`

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,274 @@
+---
+name: Savely
+description: A warm, patient, local-first savings app — the Warm Meadow system
+colors:
+  bg: "#f6f4ee"
+  surface: "#ffffff"
+  ink: "#1a1a17"
+  ink-soft: "#55524c"
+  ink-muted: "#8c8880"
+  line: "rgba(30, 25, 15, 0.08)"
+  line-soft: "rgba(30, 25, 15, 0.04)"
+  green: "#2f6b4a"
+  green-deep: "#1f4a33"
+  green-soft: "#e8f0ea"
+  green-tint: "#f2f7f3"
+  amber: "#c48a2a"
+  amber-soft: "#f6ecd6"
+  clay: "#b85c42"
+  clay-soft: "#f6e1d8"
+  sky: "#4a7ba6"
+  sky-soft: "#dce8f2"
+typography:
+  display:
+    fontFamily: "system serif (New York)"
+    fontSize: "64–72pt"
+    fontWeight: 400
+    lineHeight: 1
+  headline:
+    fontFamily: "system serif (New York)"
+    fontSize: "30–36pt"
+    fontWeight: 400
+    lineHeight: 1.1
+  title:
+    fontFamily: "system serif (New York)"
+    fontSize: "18–26pt"
+    fontWeight: 400
+    lineHeight: 1.2
+  body:
+    fontFamily: "system sans (SF Pro)"
+    fontSize: "14–15pt"
+    fontWeight: 400
+    lineHeight: 1.4
+  body-strong:
+    fontFamily: "system sans (SF Pro)"
+    fontSize: "14–15pt"
+    fontWeight: 600
+  label:
+    fontFamily: "system sans (SF Pro)"
+    fontSize: "11–13pt"
+    fontWeight: 600
+    letterSpacing: "0.8–1pt"
+rounded:
+  chip: "10pt"
+  control: "14pt"
+  row: "16pt"
+  panel: "18–20pt"
+  hero: "22–24pt"
+  sheet: "28pt"
+spacing:
+  xs: "4pt"
+  sm: "8pt"
+  md: "12pt"
+  base: "14pt"
+  lg: "16pt"
+  screen: "20pt"
+  hero: "24pt"
+components:
+  button-primary:
+    backgroundColor: "{colors.green}"
+    textColor: "#ffffff"
+    rounded: "{rounded.control}"
+    height: "48–50pt"
+  button-primary-dark-shell:
+    backgroundColor: "{colors.ink}"
+    textColor: "#ffffff"
+    rounded: "18pt"
+    size: "52pt"
+  button-icon-outline:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.control}"
+    size: "40pt"
+  chip-selected:
+    backgroundColor: "{colors.green-soft}"
+    textColor: "{colors.green-deep}"
+    rounded: "999pt"
+    padding: "8pt 14pt"
+  chip-unselected:
+    backgroundColor: "transparent"
+    textColor: "{colors.ink-soft}"
+    rounded: "999pt"
+    padding: "8pt 14pt"
+  card:
+    backgroundColor: "{colors.surface}"
+    rounded: "{rounded.row}"
+    padding: "{spacing.base}"
+  card-hero:
+    backgroundColor: "{colors.surface}"
+    rounded: "{rounded.hero}"
+    padding: "{spacing.hero}"
+  input-inline:
+    backgroundColor: "{colors.bg}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.chip}"
+    height: "40pt"
+  tile-icon:
+    backgroundColor: "{colors.green-soft}"
+    textColor: "{colors.green}"
+    rounded: "{rounded.chip}"
+    size: "36pt"
+---
+
+# Design System: Savely
+
+## Overview
+
+**Creative North Star: "Warm Meadow"**
+
+Savely looks like a well-made notebook that something is growing in. A
+warm off-white page, a serif that speaks quietly, and small tinted tiles
+that hold one glyph each — never a dashboard, never a bank. Density is
+low on purpose: one hero object per screen (the favorite goal, the amount
+being typed, the month's total), then a short list. The eye is meant to
+land once and rest.
+
+Color is restrained: one committed green carries every primary action and
+every "money in" signal; amber, clay and sky exist only as soft tiles
+behind icons and as one-word category tints. Ink does the rest. Depth is
+flat by rule — a 1px hairline and a white surface on a warm ground are the
+whole vocabulary; shadows survive only on the hero card and modal sheets.
+
+Confirmed rejections: bank-fintech purple/neon and balance cards; SaaS
+KPI grids and pie charts; cold gray-on-white spreadsheets.
+
+**Key Characteristics:**
+- Serif display, sans body — one contrast axis, no third face.
+- One green, three soft tints, warm ink. Nothing saturated except the CTA.
+- Hairline borders instead of shadows; surface-on-ground instead of elevation.
+- Generous radii (14–24pt) that get larger as the object gets more important.
+- Motion is one short entrance per screen, spring damping ≥ 0.9, no bounce.
+
+## Colors
+
+A warm neutral ground with a single committed green; everything else is a soft tint that holds an icon.
+
+### Primary
+- **Meadow Green** (`green`, #2f6b4a): the only saturated color. Primary buttons, income figures, active tab, progress rings, selected-state text. It is what "growing" looks like.
+- **Meadow Green Deep** (`green-deep`, #1f4a33): text on green-soft chips and banners; darker end of the ring gradient.
+- **Meadow Green Soft** (`green-soft`, #e8f0ea): selected chip fill, income icon tile, the auto-move banner. Never text.
+- **Meadow Green Tint** (`green-tint`, #f2f7f3): selected row background in goal pickers; the tip-of-the-day card. The quietest possible "this one".
+
+### Secondary (category tints — icons and chips only)
+- **Amber** (`amber`, #c48a2a) on **Amber Soft** (`amber-soft`, #f6ecd6): coffee / expense category, the "favorite" star, the identity monogram tile.
+- **Clay** (`clay`, #b85c42) on **Clay Soft** (`clay-soft`, #f6e1d8): shopping / receipt scanning tile; the *only* negative-trend color (income badge going down).
+- **Sky** (`sky`, #4a7ba6) on **Sky Soft** (`sky-soft`, #dce8f2): goals / transit tile.
+
+### Neutral
+- **Warm Ground** (`bg`, #f6f4ee): every screen background and every inline input field. Deliberately not white.
+- **Paper** (`surface`, #ffffff): cards, rows, action sheets, tab bar. Sits on the ground with a hairline, never a shadow.
+- **Warm Ink** (`ink`, #1a1a17): all display and title type; primary body; the dark "+" shell and the scan-receipt banner.
+- **Warm Ink Soft** (`ink-soft`, #55524c): body copy under a title, unselected chip text, settings icons.
+- **Warm Ink Muted** (`ink-muted`, #8c8880): metadata — dates, "August · $500", uppercase section labels, placeholders. **Measured 3.2:1 on ground / 3.5:1 on paper: passes AA only as large text (≥18pt or bold ≥14pt).** Its current use at 12–13pt regular is a known AA gap, tracked in `docs/plans/pr-d-profile.md`.
+- **Hairline** (`line`, 8% warm black) and **Hairline Soft** (`line-soft`, 4%): card borders and row dividers respectively. This *is* the depth system.
+
+### Named Rules
+**The One Green Rule.** Meadow Green is the only saturated fill on any screen, and it appears on at most one primary action plus the income figures. Amber, clay and sky never fill a button.
+
+**The Soft-Holds-a-Glyph Rule.** The `-soft` tints exist to sit behind a single icon or a single selected chip. They are never a text color and never a card background.
+
+**The Ink-Not-Gray Rule.** Muted text is warm ink at lower lightness, never a neutral gray. Anything that must be *read* (not skimmed) is `ink-soft` or darker.
+
+## Typography
+
+**Display Font:** system serif (New York on iOS), regular weight only
+**Body Font:** system sans (SF Pro)
+**Label Font:** SF Pro semibold, uppercase, tracked
+
+**Character:** A book face for anything that names a thing (screen title, goal name, an amount being typed) and the system sans for anything that explains it. The serif is never bolded — its size carries the hierarchy, its regular weight carries the calm.
+
+### Hierarchy
+- **Display** (regular, 64–72pt, tight): the amount on the keypad screens ("+$500"). One per screen, monospaced digits, scales down to 40% before it wraps.
+- **Headline** (regular, 30–36pt): screen titles ("Expenses", "Goals", "Evening."), onboarding titles, the "Planted." moment.
+- **Title** (regular, 18–26pt): card headings ("Recent", "Achievements"), goal names, sheet titles ("Log income", "What's the move?").
+- **Body** (regular 400 / strong 600, 14–15pt): row primary text, descriptions, button labels. Row titles are 600; supporting copy 400.
+- **Label** (600, 11–13pt, tracking 0.8–1pt, uppercase): section kickers ("FAVORITE GOAL", "SETTINGS", "HISTORY", "7-MONTH TREND") and metadata lines. This is an incumbent, committed convention — one kicker style used consistently, not a new pattern to add elsewhere.
+- **Figures**: every money figure uses `.monospacedDigit()`. Non-tabular money is a bug.
+
+### Named Rules
+**The Serif-Names, Sans-Explains Rule.** If it is the name of a thing or the number that matters, it is serif. If it tells you what to do with it, it is sans.
+
+**The Regular-Serif Rule.** The serif is never used above weight 400. Emphasis comes from size and from ink, not from boldness.
+
+## Layout
+
+Single-column, 20pt screen inset on both edges, content stacked with a base rhythm of 14pt between siblings and 16–18pt between sections. Every screen is a `ScrollView` under a hidden navigation bar; the title lives in the content, not in the chrome. One hero object first (goal card, month total, the amount being typed), then supporting rows.
+
+Cards use 14pt inner padding; the hero goal card uses 24pt. Rows inside a card are 12–14pt tall-padded and separated by a soft hairline inset 58pt from the leading edge (past the icon tile). Two-up summary cells sit in an `HStack` with 10pt gap. The tab bar is custom: 4 items around a raised 52pt dark "+" shell, 28pt bottom padding into the home indicator.
+
+Sheets: `.presentationCornerRadius(28)`, drag indicator hidden and drawn manually as a 40×4 capsule in `line`. Action-sheet detent 540pt; entry sheets `.large`.
+
+## Elevation & Depth
+
+**Flat by rule.** Depth is conveyed by a white surface on the warm ground plus a 1px hairline (`line`, 8%). Row separation uses `line-soft` (4%). There is no shadow vocabulary for cards, rows, chips or inputs.
+
+### Shadow Vocabulary
+- **Hero lift** (`Color.black.opacity(0.04–0.06), radius 12–16, y 4–8`): the favorite goal card on the dashboard and the goal detail card. The one object allowed to float.
+- **Shell shadow** (`black 0.18 / green 0.38, radius 10, y 4`): the raised "+" tab-bar shell, deeper when expanded.
+
+Everything else that still carries a `.shadow(...)` is legacy from before the Warm Meadow redesign and should lose it when touched.
+
+### Named Rules
+**The Hairline-Is-Depth Rule.** If two surfaces need separating, use `line`. If a surface needs to feel raised, it had better be the hero card or the "+" shell.
+
+## Shapes
+
+Continuous rounded rectangles throughout, with the radius growing with the object's importance: 10pt for chips, inline inputs and 36pt icon tiles; 14pt for buttons and 40pt square icon buttons; 16pt for list containers and rows; 18–20pt for panels, banners and chart cards; 22–24pt for hero and identity cards; 28pt for sheet corners. Selection chips are full capsules. Progress is a 4pt-tall capsule bar or a 12pt-stroke ring with round caps. Borders are always 1px hairline, never colored strokes — the sole exception is the 2px `green` ring on a selected radio circle.
+
+## Components
+
+Discreet and precise: wide radii without exaggeration, no heavy borders, active state shown by a soft tint rather than a solid fill. The primary button is the only solid piece on a screen.
+
+### Buttons
+- **Shape:** rounded 14pt (`control`), full width for CTAs.
+- **Primary:** `green` fill, white 15pt semibold, 48–50pt tall. Disabled: `ink-muted` fill (deposit) or 40% opacity (sheet Save).
+- **Dark shell:** the "+" tab button and the scan-receipt banner — `ink` fill, white glyph, 18–20pt radius. Expanded state turns the shell `green` and rotates the plus 45°.
+- **Icon outline:** 40×40, `surface` fill, `line` hairline, 14pt radius, `ink` glyph (bell, search — the latter removed in PR A).
+- **Text action:** `green` 13pt medium ("See all", "Save" in sheets), no chrome.
+- **Press:** system default; no custom scale. Motion elsewhere uses `.spring(response 0.28–0.35, damping 0.65–0.9)`.
+
+### Chips
+- **Style:** capsule, 13pt semibold, 8pt × 14pt padding.
+- **Selected:** category tint fill (`green-soft` / `amber-soft` …) with its deep or accent text; border matches the fill.
+- **Unselected:** clear fill, `ink-soft` text, `line` hairline border.
+- **Transition:** `.easeInOut(0.15)`.
+
+### Cards / Containers
+- **Corner Style:** 16pt for lists, 18–20pt for panels, 22–24pt for hero.
+- **Background:** `surface`; the "lifetime" card and the "Planted." screen are the only `green`-filled containers, with white type at 70–100% opacity.
+- **Shadow Strategy:** none, except the hero lift (see Elevation).
+- **Border:** 1px `line`.
+- **Internal Padding:** 14pt (16–18pt for panels, 24pt for hero).
+
+### Inputs / Fields
+- **Inline add:** 40pt tall, `bg` fill on a `surface` card, 10pt radius, `line-soft` border, 14pt text; the "$" prefix is `ink-muted`.
+- **Keypad amount:** custom 3×4 keypad, 52pt cells, serif 24pt keys on `surface`, hairline top rule; the entered amount is Display serif.
+- **Focus:** no ring; the caret is enough. Onboarding name field is the exception: 1.5px `green` border when focused.
+- **Error:** system `.alert` titled "Error" (`Strings.Errors.errorLabel`), plain-language message.
+
+### Navigation
+- Custom bottom bar: `surface`, 1px `line` top rule, four `WarmTabBarItem`s (22pt SF symbol + 10pt label, active = `green` semibold, inactive = `ink-muted`) around the raised "+" shell. Segmented control on Money uses the system `.segmented` picker.
+
+### Signature: Icon Tile
+A 36–44pt rounded square (10–12pt radius) in a `-soft` tint holding one 14–18pt SF symbol in the matching accent. It fronts every row (expense, income, goal, settings) and every onboarding page. It is how Savely says "category" without a label.
+
+### Signature: Goal Ring
+132pt ring, 12pt stroke, `green` on a warm-beige track (#ede6d4), round caps, rotated −90°, serif percentage inside. Progress bars elsewhere are 4pt capsules on `goal.trackColor`.
+
+## Do's and Don'ts
+
+### Do:
+- **Do** put the screen title in the content as a 30–36pt regular serif under a hidden nav bar.
+- **Do** separate surfaces with the 1px `line` hairline and rows with `line-soft` inset 58pt.
+- **Do** keep `.monospacedDigit()` on every money figure.
+- **Do** use a `-soft` tile + accent glyph as the row's leading element.
+- **Do** honor Reduce Motion with an instant transition; default motion is one entrance per screen, damping ≥ 0.9.
+- **Do** keep the primary CTA `green`, full-width, 48–50pt, 14pt radius.
+
+### Don't:
+- **Don't** add shadows to cards, rows, chips or inputs — the hero card and the "+" shell are the only lifted objects.
+- **Don't** fill a button with amber, clay or sky, and don't use a `-soft` tint as a card background.
+- **Don't** bold the serif or use it below 18pt.
+- **Don't** introduce gradients, glass, or a second accent hue.
+- **Don't** hardcode `.white` / `Color(red:…)` in a view — every color goes through `Color+Warm.swift`, which is the single place a dark scheme can be introduced.
+- **Don't** invent a new kicker or eyebrow style; the existing 11pt uppercase tracked label is the one and only.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,81 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+Casual savers — young adults who want a simple place for goals and everyday
+money, open the app for a few seconds a day, and are not finance
+enthusiasts. Primary market is Mexico / LatAm and US; UI is written in
+English first and translated to es-419.
+
+They use it in ordinary moments: after a purchase, on payday, at the end of
+the week. The job is "put this movement down and see where my goal stands"
+— never analysis, never a session.
+
+## Product Purpose
+
+Savely is a local-first personal savings app for iOS: goals with a real
+pace, income and expense logging, receipt scanning, and a payday
+"auto-move" that turns income into savings with one tap. **No accounts, no
+cloud, no bank connections** — money data lives on the phone and never
+leaves it. That premise is stated out loud in onboarding and is a feature,
+not a limitation.
+
+Success is a saver who keeps logging because the app never lies to them
+(headers say the real month, trends show drops, totals mean what they say)
+and never nags them.
+
+## Brand Personality
+
+**Warm · Patient · Discreet.**
+
+Like a well-made notebook: it accompanies without pushing. Serif display
+type, soft tinted tiles, a sprout mark that grows. Achievements exist but
+are quiet — real states from real data, no confetti, no streak pressure.
+Voice is plain and honest ("Enter a valid amount greater than zero", not
+"Oops!").
+
+## Anti-references
+
+- **Bank fintech** (Nu, Revolut, BBVA): purple/neon, balance cards,
+  trading-style charts, the feeling of a bank.
+- **Generic SaaS dashboard**: KPI grid, identical cards, pie charts.
+- **Cold spreadsheet / accountant**: dense tables, gray on white, no
+  warmth.
+
+Not an anti-reference but a boundary: gamification is allowed only in the
+quiet form already shipped (AchievementEngine states). No Duolingo
+mechanics.
+
+## Design Principles
+
+1. **Never lie with a number.** Labels and figures must agree; bad news is
+   shown, not hidden. Honesty over comfort.
+2. **Local-first is content, not absence.** No account ≠ empty profile.
+   Everything the app knows lives in SwiftData; surface it.
+3. **A dead control is worse than no control.** Empty closures, one-way
+   toggles, and switches that change nothing are removed or made real —
+   never left as decoration.
+4. **Warmth is carried by type and tint, not by chrome.** Serif display,
+   soft tiles, 1px hairlines. No shadows-as-depth, no glass, no gradients.
+5. **Patient by default.** One short entrance per screen, damping ≥ 0.9,
+   no bounce. Reduce Motion means instant.
+
+## Accessibility & Inclusion
+
+Target **WCAG AA, formally, across the whole app** — not only new
+surfaces:
+
+- Text contrast ≥ 4.5:1 (body) / ≥ 3:1 (large) in **both** color schemes.
+- Dynamic Type respected on every screen (no fixed `.system(size:)` that
+  clips at accessibility sizes).
+- **VoiceOver on every flow**, not just the critical ones: every control
+  has a label, every custom row has a trait, every toggle announces its
+  state, decorative images are hidden.
+- Reduce Motion honored (already the house rule for onboarding; extend
+  everywhere).
+- Both es-419 and en must pass; string length differences must not break
+  layouts.

--- a/docs/plans/pr-d-profile.md
+++ b/docs/plans/pr-d-profile.md
@@ -1,0 +1,155 @@
+# PR D — Profile: real settings, real identity
+
+**Source:** live diagnosis 2026-08-15 (see *Evidence*), the inert-affordance
+thread from `docs/plans/money-surfaces-audit.md`, and the Impeccable
+product/design pass that produced `PRODUCT.md` + `DESIGN.md` (2026-08-15).
+**Depends on:** PR A merged (Weekly PDF row already wired). Independent of
+PR B and PR C.
+**Followed by:** `pr-d2-adaptive-palette.md` (dark mode) and
+`pr-d3-accessibility.md` (VoiceOver + Dynamic Type across the whole app).
+The Dark Mode row ships **hidden** in this PR and is re-enabled by D2.
+**Branch:** `feat/profile-real-settings` off `dev`, PR back to `dev`
+(developer merges manually — never merge yourself).
+**Complexity:** Medium.
+
+> Read `CLAUDE.md`, `PRODUCT.md`, `DESIGN.md`, `.claude/knowledge/gotchas.yaml`,
+> and the **Repo traps** section of `docs/plans/pr-a-honesty-correctness.md`
+> (pbxproj procedure, commit-msg hook ≤72 chars, XCTest, SwiftLint ratchet).
+> **Do not change the current look.** DESIGN.md is the record of what the
+> app looks like today; this PR adds content and makes controls real, it
+> does not restyle.
+
+## Context
+
+The Profile tab reads as an afterthought: a name nobody set, one real
+number, six padlocks, and three settings rows of which one is dead, one is
+one-way, and one changes nothing. Savely has **no accounts by design** —
+onboarding says so out loud. The fix is not registration; it is to stop
+treating the absence of an account as an absence of content. Everything
+this screen needs is already in SwiftData (`PRODUCT.md` principle 2:
+*local-first is content, not absence*).
+
+## Evidence (verified in the simulator, 2026-08-15)
+
+| Symptom | Root cause | File |
+|---|---|---|
+| Bell button does nothing | `Button(action: {})` | `ProfileView.swift:27` |
+| Notifications toggle is one-way | `handleExpenseReminderToggle()` only *cancels*; on never re-schedules. Console: `cancelled` on off, nothing on on | `ProfileViewModel.swift:~184` |
+| Setting forgets itself | `@Published var expenseReminders = true` is not persisted; resets to on every launch while the reminder stays cancelled | `ProfileViewModel.swift:19` |
+| `goalAlerts` can never be turned off | Onboarding schedules `goalAlert`; no UI binds `goalAlerts` | `OnboardingView.swift:87` |
+| Reminder times cannot be changed | `@State` in onboarding, used once, stored nowhere | `OnboardingView.swift:12-13` |
+| Onboarding cannot decline reminders | The step only picks times; finishing always schedules both | `OnboardingView.swift:74-95` |
+| Dark Mode changes nothing | `.preferredColorScheme` **is** applied (status bar flips) but every surface paints a hardcoded light constant | `Color+Warm.swift` → **PR D2** |
+| Dark Mode switch looks stuck | `@AppStorage` inside an `ObservableObject` never fires `objectWillChange`; persists, does not re-render | `ProfileViewModel.swift:18` |
+| Toggles have no VoiceOver name | `Toggle("", isOn:).labelsHidden()` — announces "Switch, on" with no label | `ProfileView.swift:233` → set here, generalized in **D3** |
+| Nested `NavigationStack` | ProfileView wraps itself although `MainNavigationView` already does | `ProfileView.swift:21` |
+
+**Needs a human hand first:** under the automation harness the toggles
+flip on a *drag* but not on a synthetic *tap* (a `Button` in the same
+container taps fine). Tap both switches with your finger before building.
+If they respond, drop this; if not, the nested `NavigationStack` is the
+first suspect.
+
+## Decisions (already taken)
+
+- Dark mode **is** in scope — split: D hides the row behind
+  `FeatureFlags.darkModeEnabled = false`; **D2** makes the palette adaptive
+  and flips the flag. Never ship a switch that does nothing.
+- VoiceOver + Dynamic Type must cover the **whole app** → **D3**. This PR
+  sets the bar on the surfaces it touches (every new control labeled,
+  every new text scalable) but does not audit other screens.
+- Bell: **remove** (consistent with PR A's treatment of dead affordances).
+- Identity: "no account, but a real profile" — commit 3 in full.
+
+## Commits
+
+### 1. Make notification settings real and two-way
+
+- Persist in `ProfileViewModel`, backed by explicit `UserDefaults` reads
+  plus `@Published` (not `@AppStorage`, see the re-render trap):
+  `expenseRemindersEnabled`, `goalAlertsEnabled`, `expenseReminderTime`,
+  `goalAlertTime`.
+- `handleExpenseReminderToggle()` becomes symmetric: off →
+  `cancelNotification`, on → `scheduleNotification` at the stored time.
+  Same for goal alerts. Changing a time re-schedules under the same id.
+- Settings section shows both reminders with their times — the first time
+  `goalAlert` can be turned off at all. Use the system `Toggle` and a
+  `DatePicker(.hourAndMinute)` (platform controls, `DESIGN.md` Navigation
+  / ios.md), styled inside the existing `ProfileSection` rows.
+- Denied-permission state: if `UNUserNotificationCenter` authorization is
+  `.denied`, render the rows disabled with a one-line hint and a
+  "Open Settings" text action (`UIApplication.openSettingsURLString`)
+  instead of a switch that silently no-ops.
+- **Onboarding:** add a per-reminder opt-out (Toggle, default on) on the
+  notifications step and write times + enabled through the same
+  persistence, so onboarding and Profile agree.
+- **Accessibility on what you touch:** every `Toggle` gets a real label
+  (`Toggle("Expense reminder", isOn:)`, hide the *visual* label if the row
+  already shows it — never `Toggle("")`); the time picker gets
+  `.accessibilityLabel`; new text uses `Font.warm(...)` from D3's helper if
+  it has landed, otherwise `.system(size:, relativeTo:)`-equivalent via
+  `@ScaledMetric`.
+- **Validate:** unit-test the schedule/cancel decision (pure function over
+  `enabled × time`, no `UNUserNotificationCenter`). Simulator: off →
+  `cancelled` in console; on → `Scheduled`; relaunch → state persists;
+  VoiceOver reads "Expense reminder, switch, on".
+
+### 2. Remove the dead bell
+
+`ProfileView.swift:27` — delete the button and its `HStack`; the top-right
+slot is simply empty (the greeting on Dashboard has no bell either).
+
+### 3. Give the screen real content
+
+Everything below is derived from existing SwiftData. No new entities.
+Composition follows `DESIGN.md`: one hero object, then rows; hairline
+depth; serif names, sans explains; `-soft` tile + glyph as row lead.
+
+- **Identity card:** name (the one thing the user set) + "Saving since
+  <month of first logged movement>" in `ink-muted`… **use `ink-soft`** for
+  this line (it must be readable — see the AA note in D2). The whole card
+  is the edit affordance; drop the chevron-in-a-box.
+- **Stats strip** replacing the lone lifetime-income card: lifetime income
+  stays as the serif headline inside the green card; underneath, a
+  three-up row of `surface` cells — *saved across goals · movements
+  logged · active goals*. No streak counter (PRODUCT.md: no streak
+  pressure).
+- **Achievements:** six padlocks on a fresh install is the "simplón".
+  Show the **next** achievement as a single row: its `-soft` tile + glyph,
+  name, and a 4pt capsule progress bar ("3 of 5 movements"). Unlocked
+  ones stay as the tile row above it. `AchievementEngine` already computes
+  the states.
+- **Data & privacy section:** "Your data never leaves this iPhone" as the
+  section's one-line intro (this is the product's premise stated as a
+  feature), Weekly PDF export (wired in PR A), and a destructive
+  "Delete all data" with `confirmationDialog` + a second explicit confirm.
+- Remove ProfileView's own `NavigationStack`.
+- **Validate:** fresh-install and populated screenshots side by side; the
+  empty state must look deliberate, not broken. That is the acceptance
+  bar for this commit.
+
+### 4. Hide Dark Mode until D2
+
+Add `FeatureFlags.darkModeEnabled = false` and gate the row. Leave the
+`@AppStorage("darkModeEnabled")` plumbing and `.preferredColorScheme` in
+`SavelyApp.swift` in place — D2 turns them on.
+
+## Out of scope
+
+Categories/sources (PR B) · goal editing, deposit ledger, pace math
+(PR C) · the adaptive palette itself (D2) · app-wide VoiceOver / Dynamic
+Type / touch-target pass (D3) · `Double`→cents · accounts or sync (against
+the premise) · tips (behind `FeatureFlags.tipsEnabled`) · restyling
+anything documented in `DESIGN.md`.
+
+## Acceptance
+
+- [ ] `xcodebuild build` + `xcodebuild test -skip-testing:SavelyUITests` green
+- [ ] `swiftlint lint --strict` → 0 violations
+- [ ] Notification toggles survive a relaunch and are two-way (console, both directions)
+- [ ] Denied-permission state renders the hint, not a dead switch
+- [ ] No empty closures left in `ProfileView.swift`; no `Toggle("")`
+- [ ] Fresh-install Profile screenshot looks intentional
+- [ ] VoiceOver walk of the Profile tab: every control has a name and a state
+- [ ] Simulator walk-through, then **uninstall the app** (house rule)
+- [ ] Conventional commits, no AI attribution, PR to `dev`, CI green, do NOT merge

--- a/docs/plans/pr-d2-adaptive-palette.md
+++ b/docs/plans/pr-d2-adaptive-palette.md
@@ -1,0 +1,154 @@
+# PR D2 — Adaptive palette: Warm Meadow under a lamp
+
+**Source:** Impeccable design pass 2026-08-15 (`DESIGN.md`), contrast
+measurements below, `reference/ios.md` (Dark Mode is a first-class
+appearance; semantic colors, not raw hex).
+**Depends on:** PR D merged (the Dark Mode row is hidden behind
+`FeatureFlags.darkModeEnabled`; this PR flips it).
+**Branch:** `feat/adaptive-palette` off `dev`, PR back to `dev` (developer
+merges manually).
+**Complexity:** Large in surface area, small in design risk: one file
+defines the palette, ~97 call sites route through it, every screen gets
+re-checked in both schemes.
+
+> **The light appearance does not change.** Every light value in
+> `DESIGN.md`'s frontmatter is preserved byte-for-byte except the two AA
+> corrections listed under *Decisions* — and those only if the owner
+> accepts them. Dark is the *same notebook under a lamp*: warm, low
+> chroma, one green; not a neutral-gray inversion.
+
+## Evidence
+
+- `Color+Warm.swift` holds 18 tokens, all light-only constants.
+  `.preferredColorScheme` already flips with the switch (status bar
+  proves it) — nothing else listens.
+- **0** uses of `@Environment(\.colorScheme)` in the app.
+- Hardcodes outside the palette file (must be routed through tokens or
+  they will stay light in dark): **29 `Color(red:…)`, 57 `.white`,
+  11 `.black`, 5 legacy `Color("primaryGreen"…)` asset refs**.
+- 12 `.shadow(...)` calls; only the hero-card lift and the "+" shell are
+  by rule (`DESIGN.md` Elevation). The rest are legacy.
+
+### Contrast today (light) — WCAG AA
+
+| pair | ratio | AA text 4.5 | AA large/graphic 3.0 |
+|---|---|---|---|
+| ink / bg · surface | 15.9 · 17.4 | ✓ | ✓ |
+| ink-soft / bg · surface | 7.1 · 7.8 | ✓ | ✓ |
+| **ink-muted #8c8880 / bg · surface** | **3.21 · 3.53** | **✗** | ✓ |
+| green / bg · surface · green-soft | 5.8 · 6.3 · 5.4 | ✓ | ✓ |
+| white on green (CTA) | 6.3 | ✓ | ✓ |
+| **amber #c48a2a on amber-soft** | **2.55** | ✗ | **✗** |
+| clay on clay-soft · surface | 3.6 · 4.5 | ✗ · ✓ | ✓ |
+| sky on sky-soft | 3.6 | ✗ | ✓ |
+
+`ink-muted` is used at 12–13pt regular for metadata everywhere ("August ·
+$500", dates, kickers). That is body text under AA and it fails.
+
+## Decisions
+
+1. **Implementation:** keep the `Color.warm*` API exactly as is; change
+   the definitions to dynamic colors:
+   ```swift
+   static let warmBg = Color(light: 0xF6F4EE, dark: 0x161512)
+   ```
+   with a tiny private helper built on
+   `UIColor { $0.userInterfaceStyle == .dark ? dark : light }`. Zero
+   call-site changes for the 18 existing tokens. (Asset-catalog color sets
+   would also work; the code-defined helper keeps the palette in one
+   reviewable file and matches how the app already defines color.)
+2. **New tokens** for what is hardcoded today, named by role not by hue:
+   `warmOnGreen` (white on green fills, both schemes), `warmTrack` (ring
+   track, was `Color(red: .93,.90,.83)`), `warmShadow` (hero lift),
+   `warmLilac` / `warmLilacSoft` (the "New goal" quick action, was two
+   inline `Color(red:…)`), plus whatever the sweep finds. `.white` used as
+   *ink on a dark shell* becomes `warmOnInk`. Genuinely-white things (the
+   sprout mark on the splash) stay `.white`.
+3. **AA corrections in light — owner's call, both imperceptible:**
+   - `warmInkMuted` `#8c8880` → **`#746f66`** (4.54:1 on bg, 4.99 on
+     surface). Same warm-ink family, one step darker. This is the only way
+     "AA formal" and "12pt muted metadata" coexist without restyling.
+     Alternative if declined: keep the value and move every ≤13pt use of
+     `ink-muted` to `ink-soft` — a much larger, more visible change.
+   - `warmAmber` `#c48a2a` → **`#a8741c`** where it is a *glyph on
+     amber-soft* (3.45:1). Keep `#c48a2a` for the favorite star and the
+     monogram if you prefer — those are decorative; declare it.
+   If declined, note the deviation from PRODUCT.md's AA commitment in the
+   PR body rather than silently failing it.
+4. **Legacy `ColorPalette` assets** (`primaryGreen`, `cardBackgroundColor`,
+   `listBackgroundColor`, `primaryBlue` — 5 refs): route to the nearest
+   Warm token and delete the asset sets in the same PR.
+5. **Shadows:** the hero lift and the "+" shell keep theirs (`warmShadow`
+   token, darker in dark). The remaining legacy `.shadow(...)` calls go.
+
+## Dark palette (proposed — verified AA)
+
+Same hue family as light, chroma kept low, one green. Ratios computed
+against the dark ground/surface; all text pairs ≥ 4.5, all glyph/tile
+pairs ≥ 3.0.
+
+| token | light (unchanged) | dark | check |
+|---|---|---|---|
+| bg | `#f6f4ee` | `#161512` | — |
+| surface | `#ffffff` | `#262420` | sep 1.18 + hairline (depth is the hairline by rule) |
+| ink | `#1a1a17` | `#f2efe7` | 15.9 / 14.3 ✓ |
+| ink-soft | `#55524c` | `#c6c1b5` | 10.2 / 9.2 ✓ |
+| ink-muted | `#8c8880` (→ `#746f66` if D.3 accepted) | `#9d978a` | 6.3 / 5.7 ✓ |
+| line | warm black 8% | warm white 10% | — |
+| line-soft | warm black 4% | warm white 5% | — |
+| green (text/icon) | `#2f6b4a` | `#78b58f` | 7.7 / 6.9 ✓ |
+| green-fill (CTA, income card) | `#2f6b4a` | `#2f6b4a` (unchanged, white text 6.3 ✓) | ✓ |
+| green-deep (text on green-soft) | `#1f4a33` | `#b6dcc4` | 8.4 on green-soft ✓ |
+| green-soft | `#e8f0ea` | `#22382c` | — |
+| green-tint | `#f2f7f3` | `#1b2a21` | — |
+| amber | `#c48a2a` (`#a8741c` on tile) | `#dea64a` | 6.0 on amber-soft ✓ |
+| amber-soft | `#f6ecd6` | `#3a2f19` | — |
+| clay | `#b85c42` | `#d9846a` | 4.9 tile ✓ · 5.8 as trend-down text ✓ |
+| clay-soft | `#f6e1d8` | `#3d2721` | — |
+| sky | `#4a7ba6` | `#7ea9d0` | 5.7 tile ✓ |
+| sky-soft | `#dce8f2` | `#1e2d3b` | — |
+| track (new) | `#ede6d4` | `#3a362e` | ring 5.0 vs track ✓ |
+| onGreen / onInk (new) | `#ffffff` | `#ffffff` / `#f2efe7` | ✓ |
+
+Note `green` splits into *text/icon* (lightened for dark) and *fill*
+(unchanged): the CTA stays the same Meadow Green in both schemes with
+white text; only green *as ink* brightens. That is what keeps dark from
+reading as a different brand.
+
+## Commits
+
+1. **Palette:** dynamic-color helper + all 18 tokens get a dark value + the
+   new role tokens. Build must be green with **no call-site changes** yet.
+2. **Sweep the hardcodes:** route the 97 sites through tokens, screen by
+   screen (Dashboard, Goals + AddGoalFlow, Money, Profile, sheets in
+   MainNavigationView, onboarding, splash). Delete legacy asset sets and
+   legacy shadows.
+3. **Flip `FeatureFlags.darkModeEnabled = true`.** Also honor the system:
+   `.preferredColorScheme(darkModeEnabled ? .dark : nil)` — a user who
+   never touched the switch follows iOS; the switch forces dark. (Today
+   `false` forces *light*, which overrides a system-dark user. Confirm
+   with owner; recommended.)
+4. **AA corrections** (if accepted): the two light values, one commit,
+   with before/after ratios in the message.
+
+## Validation
+
+- `xcrun simctl ui <UDID> appearance dark` / `light` between passes;
+  screenshots of **every** screen in both schemes, side by side, on iPhone
+  17 Pro (`xcrun simctl io <UDID> screenshot`).
+- Contrast re-run of the table above from the final hex values (script it;
+  paste the table into the PR body).
+- Sheets, alerts and the custom tab bar in dark; the keypad; the green
+  hero cards; `.warmGreenSoft` chips (the ones most likely to lose
+  contrast).
+- Populated data, not fresh seed (house rule), then uninstall.
+
+## Acceptance
+
+- [ ] Build + tests + `swiftlint --strict` green
+- [ ] `grep -rn "Color(red:\|\.white\b\|\.black\b" Savely --include=*.swift | grep -v Color+Warm` → only the deliberate exceptions, each with a comment
+- [ ] Both schemes screenshotted for every screen; light matches pre-PR pixel-for-pixel except the accepted AA corrections
+- [ ] Contrast table regenerated and green
+- [ ] Dark Mode row visible and working; system appearance followed when the switch is off
+- [ ] `DESIGN.md` re-documented (`/impeccable document`) with the dark values in the frontmatter
+- [ ] PR to `dev`, CI green, do NOT merge

--- a/docs/plans/pr-d3-accessibility.md
+++ b/docs/plans/pr-d3-accessibility.md
@@ -1,0 +1,97 @@
+# PR D3 — Accessibility: VoiceOver, Dynamic Type, touch targets (whole app)
+
+**Source:** PRODUCT.md commitment "WCAG AA, formally, across the whole app";
+Impeccable `audit.native` scan of the source 2026-08-15 (numbers below);
+`reference/ios.md`.
+**Depends on:** PR D2 merged (contrast in both schemes is D2's job; this PR
+assumes the palette is final). Can start in parallel on a branch but rebase
+before opening.
+**Branch:** `feat/a11y-pass` off `dev`, PR back to `dev` (developer merges
+manually).
+**Complexity:** Large but mechanical. Best done screen by screen, one commit
+each, with a VoiceOver walk per commit.
+
+> **The default look does not change.** Dynamic Type support is added so
+> that at the *default* content size every glyph renders at exactly the
+> point size it renders today; only larger accessibility sizes differ.
+
+## Evidence (source scan)
+
+| Check | Finding |
+|---|---|
+| `accessibilityLabel` / `Hint` / `Value` / `AddTraits` | **0 / 0 / 0 / 0** in the whole app |
+| `accessibilityHidden` | 1 |
+| Fixed `.system(size:)` | **268** — Dynamic Type is defeated everywhere |
+| `relativeTo:` / `@ScaledMetric` | **0 / 0** |
+| Semantic text styles (`.body`, `.caption`…) | 20 (legacy views) |
+| `accessibilityReduceMotion` | 5, all in `SplashScreenView` — onboarding entrance and sheet springs ignore it |
+| Tappable frames < 44pt | 8 × 40pt (inline "+" add buttons, icon buttons), 7 × 32pt (chevron / dismiss buttons) |
+| Icon-only controls with no label | tab-bar "+" shell, keypad ⌫ (image only), favorite star, delete-in-context-menu (labeled), quick-action rows (labeled by text), sheet dismiss ×, chevron buttons |
+| `Toggle("").labelsHidden()` | Profile settings rows — announced as "Switch, on" with no name |
+
+## Decisions
+
+1. **One font helper, no per-site rewriting of sizes.** Add
+   `Font.warm(_ size: CGFloat, weight: Font.Weight = .regular, design: Font.Design = .default, relativeTo style: Font.TextStyle = .body)`
+   that scales `size` with `UIFontMetrics(forTextStyle:)`. Then a mechanical
+   replace: `.font(.system(size: 14, weight: .semibold))` →
+   `.font(.warm(14, weight: .semibold))`. Identical at default size.
+   Display serif amounts (64–72pt) scale `relativeTo: .largeTitle` and keep
+   their existing `.minimumScaleFactor(0.4)`.
+2. **Layouts must survive AX3.** Fixed `frame(width: 70)` on the inline
+   amount fields, the 3-up stats, the 7-bar chart labels and the tab bar
+   labels are the likely breakers. Use `@ScaledMetric` for those widths or
+   let them wrap; do not clip.
+3. **Touch targets:** keep the visuals; enlarge the *hit area* to ≥ 44pt
+   with `.frame(minWidth: 44, minHeight: 44)` + `.contentShape(Rectangle())`
+   around the existing 32/40pt visuals. Nothing moves on screen.
+4. **Labels:** every icon-only control gets `.accessibilityLabel`; toggles
+   get real titles with the visual label hidden (`.labelsHidden()` after a
+   real title, never `Toggle("")`); custom rows become one element
+   (`.accessibilityElement(children: .combine)`) with a `.isButton` trait
+   where they act; money figures get `.accessibilityValue` with the
+   currency spelled out; decorative tiles/images `.accessibilityHidden(true)`.
+   Progress ring/bars expose `.accessibilityValue("38 percent")`.
+5. **Reduce Motion everywhere:** onboarding entrance, sheet spring, "+"
+   shell rotation, chip animations → instant when
+   `accessibilityReduceMotion`. Reuse the splash's pattern.
+6. **Custom tab bar stays.** ios.md prefers the system tab bar; the custom
+   one is an incumbent design decision (`DESIGN.md` Navigation). Make it
+   *behave* like one instead: `.accessibilityAddTraits(.isTabBar)` on the
+   container, `.isSelected` on the active item, labels already visible.
+   Record this as an accepted deviation.
+7. **Localization is part of AA here:** every new label goes through
+   `Strings.swift` + the catalog in **both** en and es-419 (labels are
+   read aloud; an untranslated label is a defect, not a nit).
+
+## Commits (one per surface, VoiceOver walk each)
+
+1. `Font.warm` helper + `@ScaledMetric` primitives + hit-area modifier
+   (`.tappable44()`); unit test that `Font.warm(14)` at default content
+   size equals `.system(size: 14)`'s metrics.
+2. Dashboard + HeroGoalCard + DepositSheet.
+3. Goals list + GoalDetailView + AddGoalFlow (4 steps + Planted).
+4. Money tab (Expense/Income trackers, rows, chart, inline add).
+5. MainNavigationView: tab bar, action sheet, keypad, quick sheets.
+6. Profile + Achievements + onboarding + splash.
+7. Reduce Motion sweep.
+
+## Validation
+
+- VoiceOver walk on the simulator (Accessibility Inspector audit per
+  screen; zero "no label"/"hit area too small" warnings).
+- Dynamic Type at Large (default), AX1 and AX3: screenshots per screen —
+  no clipping, no overlap, no truncated money figure.
+- Reduce Motion on: onboarding + sheets are instant.
+- Both schemes (dark from D2) at AX3.
+- Populated data, then uninstall.
+
+## Acceptance
+
+- [ ] Build + tests + `swiftlint --strict` green
+- [ ] `grep -rn "\.system(size:" Savely --include=*.swift` → 0 outside `Font.warm`
+- [ ] `grep -rn 'Toggle("")' Savely` → 0
+- [ ] Accessibility Inspector audit: 0 errors on every screen
+- [ ] AX3 screenshots for every screen, both schemes, nothing clipped
+- [ ] Every new label present in `Localizable.xcstrings` for en **and** es-419
+- [ ] PR to `dev`, CI green, do NOT merge


### PR DESCRIPTION
## Summary
- **`PRODUCT.md`** — register, users, brand personality (Warm · Patient · Discreet), anti-references, design principles, **WCAG AA whole-app** commitment. Written from the Impeccable init interview (2026-08-15).
- **`DESIGN.md`** — the Warm Meadow system *as it exists today*; frontmatter tokens are normative. Documents the current look so D/D2/D3 can be held to "do not restyle". Includes measured light-mode contrast.
- **`docs/plans/pr-d-profile.md`** — real two-way persisted notification settings (onboarding + Profile), dead bell removed, real profile content from SwiftData, Dark Mode row hidden behind `FeatureFlags.darkModeEnabled` until D2.
- **`docs/plans/pr-d2-adaptive-palette.md`** — dynamic colors behind the existing `Color.warm*` API (zero call-site changes for the 18 tokens), dark values verified against AA in a table, the 97 hardcoded color sites to sweep, legacy assets/shadows removed.
- **`docs/plans/pr-d3-accessibility.md`** — VoiceOver labels everywhere, Dynamic Type via one `Font.warm` helper (identical at default size), ≥44pt hit areas without moving pixels, Reduce Motion sweep, screen by screen.
- `CLAUDE.md` gains a short *Design context* section pointing at the above.

## Why
Live diagnosis on 2026-08-15 found the Profile tab's settings are dead or one-way (bell `{}`; Notifications toggle cancels but never re-schedules and forgets its state; Dark Mode persists but the palette is hardcoded light), and a source scan found **0 `accessibilityLabel`, 268 fixed font sizes, 0 `@ScaledMetric`, 97 hardcoded colors** — incompatible with the AA commitment. These plans sequence the fix without touching the current look.

## Decisions left to the owner (flagged inside the plans, not silently taken)
- D2 §Decisions 3: two light-mode AA corrections — `warmInkMuted #8c8880 → #746f66` (3.2:1 → 4.5:1) and `warmAmber` on tiles `→ #a8741c`. Both imperceptible; without them "AA formal" and 12pt muted metadata cannot coexist.
- D2 §Commits 3: `.preferredColorScheme(dark ? .dark : nil)` so the switch *forces* dark and otherwise follows iOS (today `false` forces light over a system-dark user).
- D §Evidence: tap the Profile toggles with a finger — under the automation harness they flip on drag but not on synthetic tap; may be a harness artifact.

## Test plan
- [x] Docs only — no build impact
- [x] Contrast tables computed from the actual hex values (WCAG relative luminance), not estimated

## Checklist
- [x] Branch prefix `docs/`, Conventional Commits, no AI attribution
- [x] No secrets staged
- [x] `CLAUDE.md` updated (new context files)