### PR TITLE
feat(profile): real two-way reminder settings and a profile with content

### DIFF
--- a/Savely.xcodeproj/project.pbxproj
+++ b/Savely.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		AA28B8C8B38F312A7623F2D2 /* AutoMoveSuggestionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AFC2151C01A7FBD2947EB51 /* AutoMoveSuggestionTests.swift */; };
 		DE826483AC71FF3EC2A603B7 /* AutoMoveSuggestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = F774124079B5BEC3DD37C743 /* AutoMoveSuggestion.swift */; };
 		A11A0002C0DE5AFE10000002 /* AmountParsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A0001C0DE5AFE10000001 /* AmountParsing.swift */; };
+		A11A0006C0DE5AFE10000006 /* ReminderSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A0005C0DE5AFE10000005 /* ReminderSettings.swift */; };
+		A11A0008C0DE5AFE10000008 /* ReminderSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A0007C0DE5AFE10000007 /* ReminderSettingsTests.swift */; };
 		A11A0004C0DE5AFE10000004 /* AmountParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A0003C0DE5AFE10000003 /* AmountParsingTests.swift */; };
 		510740529955B0B1E6EA730D /* AchievementEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62FA742D1E24F010F3273E30 /* AchievementEngineTests.swift */; };
 		F764EBD092BA4435466DD9AA /* AchievementEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12789AD27FF1A7114156F945 /* AchievementEngine.swift */; };
@@ -99,6 +101,8 @@
 		9AFC2151C01A7FBD2947EB51 /* AutoMoveSuggestionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoMoveSuggestionTests.swift; sourceTree = "<group>"; };
 		F774124079B5BEC3DD37C743 /* AutoMoveSuggestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoMoveSuggestion.swift; sourceTree = "<group>"; };
 		A11A0001C0DE5AFE10000001 /* AmountParsing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmountParsing.swift; sourceTree = "<group>"; };
+		A11A0005C0DE5AFE10000005 /* ReminderSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderSettings.swift; sourceTree = "<group>"; };
+		A11A0007C0DE5AFE10000007 /* ReminderSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderSettingsTests.swift; sourceTree = "<group>"; };
 		A11A0003C0DE5AFE10000003 /* AmountParsingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmountParsingTests.swift; sourceTree = "<group>"; };
 		62FA742D1E24F010F3273E30 /* AchievementEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchievementEngineTests.swift; sourceTree = "<group>"; };
 		12789AD27FF1A7114156F945 /* AchievementEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchievementEngine.swift; sourceTree = "<group>"; };
@@ -245,6 +249,7 @@
 			children = (
 				F774124079B5BEC3DD37C743 /* AutoMoveSuggestion.swift */,
 				A11A0001C0DE5AFE10000001 /* AmountParsing.swift */,
+				A11A0005C0DE5AFE10000005 /* ReminderSettings.swift */,
 				12789AD27FF1A7114156F945 /* AchievementEngine.swift */,
 				693B815A380D566280140319 /* FeatureFlags.swift */,
 				1DE9FE162D066EE20069AA64 /* ReportsPDFGenerator.swift */,
@@ -449,6 +454,7 @@
 			children = (
 				9AFC2151C01A7FBD2947EB51 /* AutoMoveSuggestionTests.swift */,
 				A11A0003C0DE5AFE10000003 /* AmountParsingTests.swift */,
+				A11A0007C0DE5AFE10000007 /* ReminderSettingsTests.swift */,
 				62FA742D1E24F010F3273E30 /* AchievementEngineTests.swift */,
 				1DC258182CC07DCF0002DDE3 /* SavelyTests.swift */,
 			);
@@ -675,6 +681,7 @@
 				1D36698D2CC6CB4100E84FF9 /* SplashScreenView.swift in Sources */,
 				DE826483AC71FF3EC2A603B7 /* AutoMoveSuggestion.swift in Sources */,
 				A11A0002C0DE5AFE10000002 /* AmountParsing.swift in Sources */,
+				A11A0006C0DE5AFE10000006 /* ReminderSettings.swift in Sources */,
 				F764EBD092BA4435466DD9AA /* AchievementEngine.swift in Sources */,
 				ED04D2F84390584EB7EC0615 /* WelcomeStepView.swift in Sources */,
 				699FCB7F699B1E9C9C644AF3 /* SproutMark.swift in Sources */,
@@ -731,6 +738,7 @@
 				1DC258192CC07DCF0002DDE3 /* SavelyTests.swift in Sources */,
 				AA28B8C8B38F312A7623F2D2 /* AutoMoveSuggestionTests.swift in Sources */,
 				A11A0004C0DE5AFE10000004 /* AmountParsingTests.swift in Sources */,
+				A11A0008C0DE5AFE10000008 /* ReminderSettingsTests.swift in Sources */,
 				510740529955B0B1E6EA730D /* AchievementEngineTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Savely/Managers/NotificationManager.swift
+++ b/Savely/Managers/NotificationManager.swift
@@ -10,7 +10,7 @@ import UserNotifications
 
 class NotificationManager {
     static let shared = NotificationManager()
-    
+
     func scheduleNotification(title: String, body: String, identifier: String, date: Date) -> String? {
         let content = UNMutableNotificationContent()
         content.title = title
@@ -35,7 +35,7 @@ class NotificationManager {
         UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [identifier])
         print("Notification with identifier \(identifier) cancelled.")
     }
-    
+
     func requestAuthorization() {
         UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
             if let error = error {
@@ -46,5 +46,60 @@ class NotificationManager {
 
     func cancelAllNotifications() {
         UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
+    }
+
+    // MARK: - Reminders (expense / goal)
+
+    /// Applies the planner's decision for one reminder. Scheduling under an
+    /// existing identifier replaces the pending request, so a time change
+    /// is just another `.schedule`.
+    func apply(_ action: ReminderAction, to kind: ReminderKind) {
+        switch action {
+        case .schedule(let time):
+            _ = scheduleNotification(
+                title: kind.notificationTitle,
+                body: kind.notificationBody,
+                identifier: kind.rawValue,
+                date: time
+            )
+        case .cancel:
+            cancelNotification(with: kind.rawValue)
+        }
+    }
+
+    func apply(_ prefs: ReminderPreferences) {
+        for (kind, action) in ReminderPlanner.actions(for: prefs) {
+            apply(action, to: kind)
+        }
+    }
+
+    func authorizationStatus() async -> UNAuthorizationStatus {
+        await UNUserNotificationCenter.current().notificationSettings().authorizationStatus
+    }
+
+    /// The hour/minute a reminder is currently pending at, if any. Used
+    /// once to seed the persisted preferences for installs that onboarded
+    /// before preferences were stored (they only had the pending request).
+    func pendingReminderTime(for kind: ReminderKind, calendar: Calendar = .current) async -> Date? {
+        let requests = await UNUserNotificationCenter.current().pendingNotificationRequests()
+        guard let request = requests.first(where: { $0.identifier == kind.rawValue }),
+              let trigger = request.trigger as? UNCalendarNotificationTrigger else { return nil }
+        return calendar.date(from: trigger.dateComponents)
+    }
+}
+
+private extension ReminderKind {
+    var notificationTitle: String {
+        switch self {
+        case .expense: return Strings.Notifications.expenseReminderTitle
+        case .goal: return Strings.Notifications.goalAlertTitle
+        }
+    }
+
+    var notificationBody: String {
+        switch self {
+        case .expense: return Strings.Notifications.expenseReminderBody
+        case .goal: return Strings.Notifications.goalAlertBody
+        }
     }
 }

--- a/Savely/Resources/Localizable.xcstrings
+++ b/Savely/Resources/Localizable.xcstrings
@@ -64,6 +64,348 @@
     "+$" : {
 
     },
+    "all_achievements_unlocked_label" : {
+      "comment" : "Shown when nothing is left to unlock",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Every achievement unlocked"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todos los logros desbloqueados"
+          }
+        }
+      }
+    },
+    "cancel_button" : {
+      "comment" : "Cancel Button",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Cancel"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancelar"
+          }
+        }
+      }
+    },
+    "data_privacy_title" : {
+      "comment" : "Section header",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Data & privacy"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Datos y privacidad"
+          }
+        }
+      }
+    },
+    "data_stays_local_label" : {
+      "comment" : "One-line intro of the Data & privacy section",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your data never leaves this iPhone."
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tus datos nunca salen de este iPhone."
+          }
+        }
+      }
+    },
+    "delete_all_data_confirm_button" : {
+      "comment" : "Destructive confirm button",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delete everything"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Borrar todo"
+          }
+        }
+      }
+    },
+    "delete_all_data_confirm_message" : {
+      "comment" : "Confirmation dialog message",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Every income, expense and goal will be removed from this iPhone. Your name and reminder settings stay. This cannot be undone."
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se eliminarán todos los ingresos, gastos y metas de este iPhone. Tu nombre y tus recordatorios se conservan. Esto no se puede deshacer."
+          }
+        }
+      }
+    },
+    "delete_all_data_confirm_title" : {
+      "comment" : "Confirmation dialog title",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delete all data?"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Borrar todos los datos?"
+          }
+        }
+      }
+    },
+    "delete_all_data_label" : {
+      "comment" : "Destructive row",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delete all data"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Borrar todos los datos"
+          }
+        }
+      }
+    },
+    "delete_data_failed_message" : {
+      "comment" : "Alert when deletion fails",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Couldn't delete your data. Please try again."
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudieron borrar tus datos. Inténtalo de nuevo."
+          }
+        }
+      }
+    },
+    "edit_name_hint" : {
+      "comment" : "Accessibility hint on the identity card",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Tap to edit your name"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toca para editar tu nombre"
+          }
+        }
+      }
+    },
+    "just_started_label" : {
+      "comment" : "Subtitle under the display name when nothing is logged yet",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Just getting started"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apenas empezando"
+          }
+        }
+      }
+    },
+    "next_achievement_label" : {
+      "comment" : "Kicker above the closest locked achievement",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Next up"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Siguiente"
+          }
+        }
+      }
+    },
+    "notifications_denied_hint" : {
+      "comment" : "Shown instead of the reminder switches when permission is denied",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Notifications are off for Savely in iOS Settings."
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las notificaciones de Savely están desactivadas en Ajustes de iOS."
+          }
+        }
+      }
+    },
+    "open_settings_button" : {
+      "comment" : "Button that opens the iOS Settings app",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Open Settings"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abrir Ajustes"
+          }
+        }
+      }
+    },
+    "reminder_time_label" : {
+      "comment" : "Label next to the reminder time picker",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Time"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hora"
+          }
+        }
+      }
+    },
+    "saving_since_label" : {
+      "comment" : "Subtitle under the display name; %@ is a month and year",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Saving since %@"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ahorrando desde %@"
+          }
+        }
+      }
+    },
+    "stat_active_goals_label" : {
+      "comment" : "Stat cell: goals not yet complete",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Active goals"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Metas activas"
+          }
+        }
+      }
+    },
+    "stat_movements_label" : {
+      "comment" : "Stat cell: number of incomes + expenses logged",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Movements"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Movimientos"
+          }
+        }
+      }
+    },
+    "stat_saved_label" : {
+      "comment" : "Stat cell: total saved across goals",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Saved"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ahorrado"
+          }
+        }
+      }
+    },
     "~$%lld/mo" : {
 
     },
@@ -837,24 +1179,6 @@
         }
       }
     },
-    "expense_reminder_time_label" : {
-      "comment" : "Expense Reminder Time Label",
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Expense Reminder Time"
-          }
-        },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hora de Recordatorio de Gastos"
-          }
-        }
-      }
-    },
     "expense_reminder_title" : {
       "comment" : "Expense Reminder Title",
       "extractionState" : "extracted_with_value",
@@ -1157,24 +1481,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Seleccione la Hora de Alerta de Metas"
-          }
-        }
-      }
-    },
-    "goal_alert_time_label" : {
-      "comment" : "Goal Alert Time Label",
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Goal Alert Time"
-          }
-        },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hora de Alerta de Metas"
           }
         }
       }

--- a/Savely/Resources/Strings.swift
+++ b/Savely/Resources/Strings.swift
@@ -49,14 +49,6 @@ struct Strings {
             "notification_settings_description",
             value: "Choose the times to receive alerts for expenses and goals.",
             comment: "Notification Settings Description")
-        static let expenseReminderTimeLabel = NSLocalizedString(
-            "expense_reminder_time_label",
-            value: "Expense Reminder Time",
-            comment: "Expense Reminder Time Label")
-        static let goalAlertTimeLabel = NSLocalizedString(
-            "goal_alert_time_label",
-            value: "Goal Alert Time",
-            comment: "Goal Alert Time Label")
         static let welcomeTitle = NSLocalizedString(
             "onboarding_welcome_title",
             value: "Yours, and only yours",
@@ -261,7 +253,87 @@ struct Strings {
             "dark_mode_label",
             value: "Dark Mode",
             comment: "Dark Mode Label")
-        
+
+        // Reminders (settings + onboarding)
+        static let reminderTimeLabel = NSLocalizedString(
+            "reminder_time_label",
+            value: "Time",
+            comment: "Label next to the reminder time picker")
+        static let notificationsDeniedHint = NSLocalizedString(
+            "notifications_denied_hint",
+            value: "Notifications are off for Savely in iOS Settings.",
+            comment: "Shown instead of the reminder switches when permission is denied")
+        static let openSettingsButton = NSLocalizedString(
+            "open_settings_button",
+            value: "Open Settings",
+            comment: "Button that opens the iOS Settings app")
+
+        // Identity + stats
+        static let savingSinceLabel = NSLocalizedString(
+            "saving_since_label",
+            value: "Saving since %@",
+            comment: "Subtitle under the display name; %@ is a month and year")
+        static let justStartedLabel = NSLocalizedString(
+            "just_started_label",
+            value: "Just getting started",
+            comment: "Subtitle under the display name when nothing is logged yet")
+        static let editNameHint = NSLocalizedString(
+            "edit_name_hint",
+            value: "Tap to edit your name",
+            comment: "Accessibility hint on the identity card")
+        static let statSavedLabel = NSLocalizedString(
+            "stat_saved_label",
+            value: "Saved",
+            comment: "Stat cell: total saved across goals")
+        static let statMovementsLabel = NSLocalizedString(
+            "stat_movements_label",
+            value: "Movements",
+            comment: "Stat cell: number of incomes + expenses logged")
+        static let statActiveGoalsLabel = NSLocalizedString(
+            "stat_active_goals_label",
+            value: "Active goals",
+            comment: "Stat cell: goals not yet complete")
+
+        // Achievements
+        static let nextAchievementLabel = NSLocalizedString(
+            "next_achievement_label",
+            value: "Next up",
+            comment: "Kicker above the closest locked achievement")
+        static let allAchievementsUnlockedLabel = NSLocalizedString(
+            "all_achievements_unlocked_label",
+            value: "Every achievement unlocked",
+            comment: "Shown when nothing is left to unlock")
+
+        // Data & privacy
+        static let dataPrivacyTitle = NSLocalizedString(
+            "data_privacy_title",
+            value: "Data & privacy",
+            comment: "Section header")
+        static let dataStaysLocalLabel = NSLocalizedString(
+            "data_stays_local_label",
+            value: "Your data never leaves this iPhone.",
+            comment: "One-line intro of the Data & privacy section")
+        static let deleteAllDataLabel = NSLocalizedString(
+            "delete_all_data_label",
+            value: "Delete all data",
+            comment: "Destructive row")
+        static let deleteAllDataConfirmTitle = NSLocalizedString(
+            "delete_all_data_confirm_title",
+            value: "Delete all data?",
+            comment: "Confirmation dialog title")
+        static let deleteAllDataConfirmMessage = NSLocalizedString(
+            "delete_all_data_confirm_message",
+            value: "Every income, expense and goal will be removed from this iPhone. Your name and reminder settings stay. This cannot be undone.",
+            comment: "Confirmation dialog message")
+        static let deleteAllDataConfirmButton = NSLocalizedString(
+            "delete_all_data_confirm_button",
+            value: "Delete everything",
+            comment: "Destructive confirm button")
+        static let deleteDataFailedMessage = NSLocalizedString(
+            "delete_data_failed_message",
+            value: "Couldn't delete your data. Please try again.",
+            comment: "Alert when deletion fails")
+
         static let securityTitle = NSLocalizedString(
             "security_title",
             value: "Security",
@@ -448,6 +520,10 @@ struct Strings {
             "ok_button",
             value: "OK",
             comment: "OK Button")
+        static let cancelButton = NSLocalizedString(
+            "cancel_button",
+            value: "Cancel",
+            comment: "Cancel Button")
     }
     
     struct Camera {

--- a/Savely/Utilities/FeatureFlags.swift
+++ b/Savely/Utilities/FeatureFlags.swift
@@ -30,4 +30,11 @@ enum FeatureFlags {
     /// deposit applies together with the income save. ON for the App Store
     /// release; this flag remains as the kill switch.
     static let autoMoveSuggestionsEnabled = true
+
+    /// The Dark Mode switch in Profile. The palette in `Color+Warm.swift`
+    /// is still light-only, so flipping the switch changed nothing except
+    /// the status bar. Hidden until the adaptive palette lands
+    /// (docs/plans/pr-d2-adaptive-palette.md), which flips this back on.
+    /// The `@AppStorage("darkModeEnabled")` plumbing stays in place.
+    static let darkModeEnabled = false
 }

--- a/Savely/Utilities/ReminderSettings.swift
+++ b/Savely/Utilities/ReminderSettings.swift
@@ -1,0 +1,131 @@
+//
+//  ReminderSettings.swift
+//  Savely
+//
+//  The two local reminders (expense, goal): what the user chose, where it
+//  is stored, and the pure decision of what to do about it. Scheduling
+//  itself lives in NotificationManager; this file never touches
+//  UNUserNotificationCenter so it can be unit-tested.
+//
+
+import Foundation
+
+/// The two repeating reminders Savely can schedule. The raw value is the
+/// `UNNotificationRequest` identifier that has been in use since the first
+/// release — do not rename it or existing users' pending requests become
+/// unreachable.
+enum ReminderKind: String, CaseIterable {
+    case expense = "expenseReminder"
+    case goal = "goalAlert"
+}
+
+/// What the user chose, per reminder. Times are only meaningful as
+/// hour + minute (the trigger repeats daily).
+struct ReminderPreferences: Equatable {
+    var expenseEnabled: Bool
+    var goalEnabled: Bool
+    var expenseTime: Date
+    var goalTime: Date
+
+    func isEnabled(_ kind: ReminderKind) -> Bool {
+        switch kind {
+        case .expense: return expenseEnabled
+        case .goal: return goalEnabled
+        }
+    }
+
+    func time(for kind: ReminderKind) -> Date {
+        switch kind {
+        case .expense: return expenseTime
+        case .goal: return goalTime
+        }
+    }
+
+    mutating func setEnabled(_ enabled: Bool, for kind: ReminderKind) {
+        switch kind {
+        case .expense: expenseEnabled = enabled
+        case .goal: goalEnabled = enabled
+        }
+    }
+
+    mutating func setTime(_ time: Date, for kind: ReminderKind) {
+        switch kind {
+        case .expense: expenseTime = time
+        case .goal: goalTime = time
+        }
+    }
+
+    /// First-run defaults: both on, evening for expenses, morning for goals.
+    static func defaults(calendar: Calendar = .current, now: Date = Date()) -> ReminderPreferences {
+        ReminderPreferences(
+            expenseEnabled: true,
+            goalEnabled: true,
+            expenseTime: calendar.date(bySettingHour: 20, minute: 0, second: 0, of: now) ?? now,
+            goalTime: calendar.date(bySettingHour: 9, minute: 0, second: 0, of: now) ?? now
+        )
+    }
+}
+
+/// The one decision the settings screen and onboarding both make.
+enum ReminderAction: Equatable {
+    case schedule(at: Date)
+    case cancel
+}
+
+enum ReminderPlanner {
+    /// A reminder that is on is scheduled at its time; one that is off is
+    /// cancelled. Re-scheduling under the same identifier replaces the
+    /// pending request, so "time changed" is just `schedule` again.
+    static func action(enabled: Bool, time: Date) -> ReminderAction {
+        enabled ? .schedule(at: time) : .cancel
+    }
+
+    static func actions(for prefs: ReminderPreferences) -> [ReminderKind: ReminderAction] {
+        var result: [ReminderKind: ReminderAction] = [:]
+        for kind in ReminderKind.allCases {
+            result[kind] = action(enabled: prefs.isEnabled(kind), time: prefs.time(for: kind))
+        }
+        return result
+    }
+}
+
+/// UserDefaults-backed persistence. Kept tiny and explicit (no
+/// `@AppStorage`) so an `ObservableObject` can publish changes itself.
+struct ReminderStore {
+    private let defaults: UserDefaults
+
+    private enum Key {
+        static let expenseEnabled = "reminder.expense.enabled"
+        static let goalEnabled = "reminder.goal.enabled"
+        static let expenseTime = "reminder.expense.time"
+        static let goalTime = "reminder.goal.time"
+    }
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    /// True once onboarding (or the settings screen) has saved a choice.
+    /// Before that, callers may seed times from the pending requests of an
+    /// already-onboarded install (see `ProfileViewModel`).
+    var hasSavedPreferences: Bool {
+        defaults.object(forKey: Key.expenseEnabled) != nil
+    }
+
+    func load() -> ReminderPreferences {
+        let base = ReminderPreferences.defaults()
+        return ReminderPreferences(
+            expenseEnabled: defaults.object(forKey: Key.expenseEnabled) as? Bool ?? base.expenseEnabled,
+            goalEnabled: defaults.object(forKey: Key.goalEnabled) as? Bool ?? base.goalEnabled,
+            expenseTime: defaults.object(forKey: Key.expenseTime) as? Date ?? base.expenseTime,
+            goalTime: defaults.object(forKey: Key.goalTime) as? Date ?? base.goalTime
+        )
+    }
+
+    func save(_ prefs: ReminderPreferences) {
+        defaults.set(prefs.expenseEnabled, forKey: Key.expenseEnabled)
+        defaults.set(prefs.goalEnabled, forKey: Key.goalEnabled)
+        defaults.set(prefs.expenseTime, forKey: Key.expenseTime)
+        defaults.set(prefs.goalTime, forKey: Key.goalTime)
+    }
+}

--- a/Savely/ViewModels/ProfileTab/ProfileViewModel.swift
+++ b/Savely/ViewModels/ProfileTab/ProfileViewModel.swift
@@ -16,16 +16,13 @@ import SwiftData
 class ProfileViewModel: ObservableObject {
     @Published var displayName: String = ""
     @AppStorage("darkModeEnabled") var darkMode: Bool = false
-    @Published var expenseReminders: Bool = true {
-        didSet {
-            handleExpenseReminderToggle()
-        }
-    }
-    @Published var goalAlerts: Bool = true {
-        didSet {
-            handleGoalAlertToggle()
-        }
-    }
+
+    /// The persisted reminder choices. Mutate through the `setReminder…`
+    /// methods so the change is saved and the pending request follows.
+    @Published private(set) var reminders: ReminderPreferences
+    /// True when iOS notification permission is denied — the settings rows
+    /// then explain instead of pretending a switch does something.
+    @Published private(set) var notificationsDenied: Bool = false
 
     @Published var showAlert: Bool = false
     @Published var alertMessage: String = ""
@@ -34,9 +31,16 @@ class ProfileViewModel: ObservableObject {
     @Published var isLoading: Bool = false
 
     private var modelContext: ModelContext?
+    private let reminderStore: ReminderStore
+    private let notifications: NotificationManager
 
-    init(modelContext: ModelContext? = nil) {
+    init(modelContext: ModelContext? = nil,
+         reminderStore: ReminderStore = ReminderStore(),
+         notifications: NotificationManager = .shared) {
         self.modelContext = modelContext
+        self.reminderStore = reminderStore
+        self.notifications = notifications
+        self.reminders = reminderStore.load()
         self.displayName = UserDefaults.standard.string(forKey: "displayName") ?? ""
         if modelContext != nil {
             fetchWeeklyReportData(
@@ -53,6 +57,73 @@ class ProfileViewModel: ObservableObject {
             startDate: Calendar.current.startOfWeek(for: Date()),
             endDate: Date()
         )
+    }
+
+    // MARK: - Reminders
+
+    /// Call on appear: refreshes the permission state and, for installs
+    /// that onboarded before preferences were persisted, seeds the times
+    /// from whatever request is still pending.
+    func refreshReminderState() async {
+        notificationsDenied = await notifications.authorizationStatus() == .denied
+        guard !reminderStore.hasSavedPreferences else { return }
+        var seeded = reminders
+        for kind in ReminderKind.allCases {
+            if let pending = await notifications.pendingReminderTime(for: kind) {
+                seeded.setTime(pending, for: kind)
+                seeded.setEnabled(true, for: kind)
+            } else {
+                // No pending request for a pre-preferences install means the
+                // user turned it off (the old toggle only ever cancelled).
+                seeded.setEnabled(false, for: kind)
+            }
+        }
+        reminders = seeded
+        reminderStore.save(seeded)
+    }
+
+    func setReminder(_ kind: ReminderKind, enabled: Bool) {
+        var next = reminders
+        next.setEnabled(enabled, for: kind)
+        commit(next, kind: kind)
+    }
+
+    func setReminder(_ kind: ReminderKind, time: Date) {
+        var next = reminders
+        next.setTime(time, for: kind)
+        commit(next, kind: kind)
+    }
+
+    private func commit(_ next: ReminderPreferences, kind: ReminderKind) {
+        guard next != reminders else { return }
+        reminders = next
+        reminderStore.save(next)
+        notifications.apply(
+            ReminderPlanner.action(enabled: next.isEnabled(kind), time: next.time(for: kind)),
+            to: kind
+        )
+    }
+
+    // MARK: - Data
+
+    /// Deletes every movement, goal and stored tip. Display name and
+    /// reminder settings are kept — they are preferences, not data.
+    func deleteAllData() {
+        guard let modelContext = modelContext else { return }
+        do {
+            try modelContext.delete(model: IncomeModel.self)
+            try modelContext.delete(model: ExpenseModel.self)
+            try modelContext.delete(model: GoalModel.self)
+            try modelContext.delete(model: TipModel.self)
+            try modelContext.save()
+            UserDefaults.standard.removeObject(forKey: "celebratedAchievementIds")
+            weeklyIncomes = []
+            weeklyExpenses = []
+        } catch {
+            print("deleteAllData: \(error)")
+            alertMessage = Strings.Profile.deleteDataFailedMessage
+            showAlert = true
+        }
     }
 
     func fetchWeeklyReportData(startDate: Date, endDate: Date) {
@@ -178,17 +249,5 @@ class ProfileViewModel: ObservableObject {
         UserDefaults.standard.set(displayName, forKey: "displayName")
         alertMessage = "Your personal information has been updated successfully."
         showAlert = true
-    }
-
-    func handleExpenseReminderToggle() {
-        if !expenseReminders {
-            NotificationManager.shared.cancelNotification(with: "expenseReminder")
-        }
-    }
-
-    func handleGoalAlertToggle() {
-        if !goalAlerts {
-            NotificationManager.shared.cancelNotification(with: "goalAlert")
-        }
     }
 }

--- a/Savely/Views/Onboarding/NotificationSettingsStepView.swift
+++ b/Savely/Views/Onboarding/NotificationSettingsStepView.swift
@@ -7,11 +7,12 @@
 
 import SwiftUI
 
-/// Last onboarding page — the only functional one (pick reminder times).
+/// Last onboarding page — the only functional one: opt in or out of each
+/// reminder and pick its time. The same `ReminderPreferences` the Profile
+/// tab edits later, so the two never disagree.
 /// Warm Meadow: clay tile, serif title, bordered surface card, no shadows.
 struct NotificationSettingsStepView: View {
-    @Binding var expenseReminderTime: Date
-    @Binding var goalAlertTime: Date
+    @Binding var preferences: ReminderPreferences
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var appeared = false
 
@@ -27,6 +28,7 @@ struct NotificationSettingsStepView: View {
                 )
                 .scaleEffect(appeared ? 1 : 0.92)
                 .opacity(appeared ? 1 : 0)
+                .accessibilityHidden(true)
 
             VStack(spacing: 12) {
                 Text(Strings.Onboarding.notificationSettingsTitle)
@@ -45,29 +47,19 @@ struct NotificationSettingsStepView: View {
             .offset(y: appeared ? 0 : 10)
 
             VStack(spacing: 0) {
-                HStack {
-                    Text(Strings.Onboarding.expenseReminderTimeLabel)
-                        .font(.system(size: 14, weight: .medium))
-                        .foregroundStyle(Color.warmInk)
-                    Spacer()
-                    DatePicker("", selection: $expenseReminderTime, displayedComponents: .hourAndMinute)
-                        .labelsHidden()
-                }
-                .padding(.horizontal, 16)
-                .padding(.vertical, 12)
-
+                reminderRows(
+                    title: Strings.Profile.expenseRemindersLabel,
+                    icon: "bell.fill",
+                    enabled: $preferences.expenseEnabled,
+                    time: $preferences.expenseTime
+                )
                 WarmDivider()
-
-                HStack {
-                    Text(Strings.Onboarding.goalAlertTimeLabel)
-                        .font(.system(size: 14, weight: .medium))
-                        .foregroundStyle(Color.warmInk)
-                    Spacer()
-                    DatePicker("", selection: $goalAlertTime, displayedComponents: .hourAndMinute)
-                        .labelsHidden()
-                }
-                .padding(.horizontal, 16)
-                .padding(.vertical, 12)
+                reminderRows(
+                    title: Strings.Profile.goalAlertsLabel,
+                    icon: "target",
+                    enabled: $preferences.goalEnabled,
+                    time: $preferences.goalTime
+                )
             }
             .background(Color.warmSurface)
             .cornerRadius(16)
@@ -88,10 +80,18 @@ struct NotificationSettingsStepView: View {
             }
         }
     }
+
+    @ViewBuilder
+    private func reminderRows(title: String, icon: String, enabled: Binding<Bool>, time: Binding<Date>) -> some View {
+        SettingsToggleRow(icon: icon, title: title, isOn: enabled)
+        if enabled.wrappedValue {
+            ReminderTimeRow(time: time)
+        }
+    }
 }
 
 #Preview {
-    NotificationSettingsStepView(expenseReminderTime: .constant(Date()), goalAlertTime: .constant(Date()))
+    NotificationSettingsStepView(preferences: .constant(.defaults()))
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.warmBg)
 }

--- a/Savely/Views/Onboarding/OnboardingView.swift
+++ b/Savely/Views/Onboarding/OnboardingView.swift
@@ -9,8 +9,7 @@ import SwiftUI
 
 struct OnboardingView: View {
     @State private var currentStep = 0
-    @State private var expenseReminderTime = Date()
-    @State private var goalAlertTime = Date()
+    @State private var reminders = ReminderPreferences.defaults()
     let featureSteps = OnboardingData.steps
     @EnvironmentObject var appViewModel: AppViewModel
 
@@ -27,11 +26,8 @@ struct OnboardingView: View {
                     OnboardingStepView(step: step)
                         .tag(index + 1)
                 }
-                NotificationSettingsStepView(
-                    expenseReminderTime: $expenseReminderTime,
-                    goalAlertTime: $goalAlertTime
-                )
-                .tag(pageCount - 1)
+                NotificationSettingsStepView(preferences: $reminders)
+                    .tag(pageCount - 1)
             }
             .tabViewStyle(.page(indexDisplayMode: .never))
 
@@ -70,28 +66,11 @@ struct OnboardingView: View {
     }
 
     private func completeOnboarding() {
-        saveNotificationTimes()
+        // Persist first, then schedule only what was left on — the Profile
+        // tab reads the same store, so the two can never disagree.
+        ReminderStore().save(reminders)
+        NotificationManager.shared.apply(reminders)
         appViewModel.completeOnboarding()
-    }
-
-    private func saveNotificationTimes() {
-        if let expenseReminderID = NotificationManager.shared.scheduleNotification(
-            title: Strings.Notifications.expenseReminderTitle,
-            body: Strings.Notifications.expenseReminderBody,
-            identifier: "expenseReminder",
-            date: expenseReminderTime
-        ) {
-            print("Expense Reminder Scheduled: \(expenseReminderID)")
-        }
-
-        if let goalAlertID = NotificationManager.shared.scheduleNotification(
-            title: Strings.Notifications.goalAlertTitle,
-            body: Strings.Notifications.goalAlertBody,
-            identifier: "goalAlert",
-            date: goalAlertTime
-        ) {
-            print("Goal Alert Scheduled: \(goalAlertID)")
-        }
     }
 }
 

--- a/Savely/Views/ProfileTab/ProfileView.swift
+++ b/Savely/Views/ProfileTab/ProfileView.swift
@@ -5,156 +5,174 @@ struct ProfileView: View {
     @StateObject private var viewModel = ProfileViewModel()
     @EnvironmentObject var appViewModel: AppViewModel
     @Environment(\.modelContext) private var modelContext
+    @Environment(\.openURL) private var openURL
     @Query(sort: \IncomeModel.date, order: .reverse) private var incomes: [IncomeModel]
     @Query private var expenses: [ExpenseModel]
     @Query private var goals: [GoalModel]
     @State private var showingEditProfile = false
     @State private var showingAchievements = false
     @State private var showingTipHistory = false
+    @State private var showingDeleteDialog = false
+    @State private var showingDeleteFinalConfirm = false
 
     private var lifetimeIncome: Double { incomes.reduce(0) { $0 + $1.amount } }
     private var displayInitial: String {
         viewModel.displayName.first.map { String($0).uppercased() } ?? "U"
     }
 
+    // "Saving since <month>" — the first movement ever logged. Nothing
+    // logged yet is a deliberate state, not an empty label.
+    private var identitySubtitle: String {
+        let firstDate = (incomes.map(\.date) + expenses.map(\.date)).min()
+        guard let firstDate else { return Strings.Profile.justStartedLabel }
+        let month = firstDate.formatted(.dateTime.month(.wide).year())
+        return String(format: Strings.Profile.savingSinceLabel, month)
+    }
+
+    private var totalSaved: Double { goals.reduce(0) { $0 + $1.current } }
+    private var movementCount: Int { incomes.count + expenses.count }
+    private var activeGoalCount: Int { goals.filter { $0.progress < 1 }.count }
+
     var body: some View {
-        NavigationStack {
-            ScrollView {
-                VStack(spacing: 14) {
-                    // — Notification bell top right —
-                    HStack {
-                        Spacer()
-                        Button(action: {}) {
-                            Image(systemName: "bell")
-                                .font(.system(size: 18))
-                                .foregroundStyle(Color.warmInk)
-                                .frame(width: 40, height: 40)
-                                .background(Color.warmSurface)
-                                .cornerRadius(14)
-                                .overlay(RoundedRectangle(cornerRadius: 14).stroke(Color.warmLine, lineWidth: 1))
-                        }
-                    }
+        ScrollView {
+            VStack(spacing: 14) {
+                identityCard
                     .padding(.top, 8)
 
-                    // — Identity card —
-                    HStack(spacing: 16) {
-                        RoundedRectangle(cornerRadius: 20)
-                            .fill(Color.warmAmberSoft)
-                            .frame(width: 64, height: 64)
-                            .overlay(
-                                Text(displayInitial)
-                                    .font(.system(size: 30, weight: .regular, design: .serif))
-                                    .foregroundStyle(Color.warmAmber)
-                            )
+                lifetimeIncomeCard
 
-                        VStack(alignment: .leading, spacing: 3) {
-                            Text(viewModel.displayName.isEmpty ? "User" : viewModel.displayName)
-                                .font(.system(size: 22, weight: .regular, design: .serif))
-                                .foregroundStyle(Color.warmInk)
-                        }
-                        Spacer()
-                        Button(action: { showingEditProfile = true }) {
-                            Image(systemName: "chevron.right")
-                                .font(.system(size: 13))
-                                .foregroundStyle(Color.warmInkMuted)
-                                .frame(width: 32, height: 32)
-                                .background(Color.warmBg)
-                                .cornerRadius(10)
-                        }
+                statsStrip
+
+                achievementsCard
+
+                settingsSection
+
+                dataPrivacySection
+
+                if FeatureFlags.tipsEnabled {
+                    ProfileSection(header: "About") {
+                        SettingsNavRow(icon: "sparkles", title: "Tip history", detail: "128 tips", onTap: { showingTipHistory = true })
                     }
-                    .padding(20)
-                    .background(Color.warmSurface)
-                    .cornerRadius(22)
-                    .overlay(RoundedRectangle(cornerRadius: 22).stroke(Color.warmLine, lineWidth: 1))
-
-                    // — Lifetime savings card —
-                    ZStack(alignment: .topTrailing) {
-                        Circle()
-                            .fill(Color.white.opacity(0.08))
-                            .frame(width: 140, height: 140)
-                            .offset(x: 30, y: -20)
-
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text("LIFETIME INCOME")
-                                .font(.system(size: 11, weight: .semibold))
-                                .foregroundStyle(Color.white.opacity(0.7))
-                                .tracking(0.8)
-                            Text(formattedAmount(lifetimeIncome))
-                                .font(.system(size: 40, weight: .regular, design: .serif))
-                                .foregroundStyle(.white)
-                            Text("Total income logged in Savely")
-                                .font(.system(size: 13))
-                                .foregroundStyle(Color.white.opacity(0.75))
-                        }
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(20)
-                    }
-                    .background(Color.warmGreen)
-                    .cornerRadius(22)
-                    .clipped()
-
-                    // — Achievements preview —
-                    VStack(spacing: 12) {
-                        HStack {
-                            Text("Achievements")
-                                .font(.system(size: 18, weight: .regular, design: .serif))
-                                .foregroundStyle(Color.warmInk)
-                            Spacer()
-                            Button(action: { showingAchievements = true }) {
-                                Text("See all ›")
-                                    .font(.system(size: 13, weight: .medium))
-                                    .foregroundStyle(Color.warmGreen)
-                            }
-                        }
-                        HStack(spacing: 10) {
-                            ForEach(badgePreviews, id: \.icon) { b in
-                                BadgeTile(icon: b.icon, bg: b.bg, color: b.color, unlocked: b.unlocked)
-                            }
-                        }
-                    }
-                    .padding(16)
-                    .background(Color.warmSurface)
-                    .cornerRadius(20)
-                    .overlay(RoundedRectangle(cornerRadius: 20).stroke(Color.warmLine, lineWidth: 1))
-
-                    // — Settings —
-                    ProfileSection(header: "Settings") {
-                        SettingsToggleRow(icon: "bell.fill", title: "Notifications", isOn: $viewModel.expenseReminders)
-                        WarmDivider()
-                        SettingsToggleRow(icon: "moon.fill", title: "Dark Mode", isOn: $viewModel.darkMode)
-                        WarmDivider()
-                        SettingsNavRow(icon: "doc.text.fill", title: "Weekly PDF report", onTap: { viewModel.generateWeeklyReportPDF() })
-                    }
-
-                    if FeatureFlags.tipsEnabled {
-                        ProfileSection(header: "About") {
-                            SettingsNavRow(icon: "sparkles", title: "Tip history", detail: "128 tips", onTap: { showingTipHistory = true })
-                        }
-                    }
-
-                    Spacer(minLength: 16)
                 }
-                .padding(.horizontal, 20)
-                .padding(.bottom, 24)
+
+                Spacer(minLength: 16)
             }
-            .background(Color.warmBg)
-            .navigationBarHidden(true)
-            .alert(isPresented: $viewModel.showAlert) {
-                Alert(title: Text(Strings.Errors.noticeLabel), message: Text(viewModel.alertMessage), dismissButton: .default(Text(Strings.Buttons.okButton)))
+            .padding(.horizontal, 20)
+            .padding(.bottom, 24)
+        }
+        .background(Color.warmBg)
+        .navigationBarHidden(true)
+        .alert(isPresented: $viewModel.showAlert) {
+            Alert(title: Text(Strings.Errors.noticeLabel), message: Text(viewModel.alertMessage), dismissButton: .default(Text(Strings.Buttons.okButton)))
+        }
+        .confirmationDialog(
+            Strings.Profile.deleteAllDataConfirmTitle,
+            isPresented: $showingDeleteDialog,
+            titleVisibility: .visible
+        ) {
+            Button(Strings.Profile.deleteAllDataConfirmButton, role: .destructive) { showingDeleteFinalConfirm = true }
+            Button(Strings.Buttons.cancelButton, role: .cancel) {}
+        } message: {
+            Text(Strings.Profile.deleteAllDataConfirmMessage)
+        }
+        // Second, explicit confirm — deleting is the one irreversible thing here.
+        .alert(Strings.Profile.deleteAllDataConfirmTitle, isPresented: $showingDeleteFinalConfirm) {
+            Button(Strings.Profile.deleteAllDataConfirmButton, role: .destructive) { viewModel.deleteAllData() }
+            Button(Strings.Buttons.cancelButton, role: .cancel) {}
+        } message: {
+            Text(Strings.Profile.deleteAllDataConfirmMessage)
+        }
+        .sheet(isPresented: $showingEditProfile) { EditProfileSheet(viewModel: viewModel) }
+        .navigationDestination(isPresented: $showingAchievements) { AchievementsView() }
+        .navigationDestination(isPresented: $showingTipHistory) { TipHistoryView() }
+        .onAppear { viewModel.setModelContext(modelContext) }
+        .task { await viewModel.refreshReminderState() }
+    }
+
+    // MARK: - Identity
+
+    private var identityCard: some View {
+        Button(action: { showingEditProfile = true }) {
+            HStack(spacing: 16) {
+                RoundedRectangle(cornerRadius: 20)
+                    .fill(Color.warmAmberSoft)
+                    .frame(width: 64, height: 64)
+                    .overlay(
+                        Text(displayInitial)
+                            .font(.system(size: 30, weight: .regular, design: .serif))
+                            .foregroundStyle(Color.warmAmber)
+                    )
+                    .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(viewModel.displayName.isEmpty ? "User" : viewModel.displayName)
+                        .font(.system(size: 22, weight: .regular, design: .serif))
+                        .foregroundStyle(Color.warmInk)
+                    Text(identitySubtitle)
+                        .font(.system(size: 13))
+                        .foregroundStyle(Color.warmInkSoft)
+                }
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 13))
+                    .foregroundStyle(Color.warmInkMuted)
+                    .accessibilityHidden(true)
             }
-            .sheet(isPresented: $showingEditProfile) { EditProfileSheet(viewModel: viewModel) }
-            .navigationDestination(isPresented: $showingAchievements) { AchievementsView() }
-            .navigationDestination(isPresented: $showingTipHistory) { TipHistoryView() }
-            .onAppear { viewModel.setModelContext(modelContext) }
+            .padding(20)
+            .background(Color.warmSurface)
+            .cornerRadius(22)
+            .overlay(RoundedRectangle(cornerRadius: 22).stroke(Color.warmLine, lineWidth: 1))
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityHint(Strings.Profile.editNameHint)
+    }
+
+    // MARK: - Lifetime income (unchanged)
+
+    private var lifetimeIncomeCard: some View {
+        ZStack(alignment: .topTrailing) {
+            Circle()
+                .fill(Color.white.opacity(0.08))
+                .frame(width: 140, height: 140)
+                .offset(x: 30, y: -20)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("LIFETIME INCOME")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(Color.white.opacity(0.7))
+                    .tracking(0.8)
+                Text(formattedAmount(lifetimeIncome))
+                    .font(.system(size: 40, weight: .regular, design: .serif))
+                    .foregroundStyle(.white)
+                Text("Total income logged in Savely")
+                    .font(.system(size: 13))
+                    .foregroundStyle(Color.white.opacity(0.75))
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(20)
+        }
+        .background(Color.warmGreen)
+        .cornerRadius(22)
+        .clipped()
+        .accessibilityElement(children: .combine)
+    }
+
+    // MARK: - Stats
+
+    private var statsStrip: some View {
+        HStack(spacing: 10) {
+            ProfileStatCell(label: Strings.Profile.statSavedLabel, value: formattedAmount(totalSaved))
+            ProfileStatCell(label: Strings.Profile.statMovementsLabel, value: "\(movementCount)")
+            ProfileStatCell(label: Strings.Profile.statActiveGoalsLabel, value: "\(activeGoalCount)")
         }
     }
 
-    // Badge previews — the first six real achievement states (AchievementEngine,
-    // 2026-08). Unlocked show their tile colors; locked show a lock.
-    private struct BadgePreview { let icon: String; let bg: Color; let color: Color; let unlocked: Bool }
-    private var badgePreviews: [BadgePreview] {
-        let states = AchievementEngine.evaluate(AchievementInput(
-            incomeTotal: incomes.reduce(0) { $0 + $1.amount },
+    // MARK: - Achievements
+
+    private var achievementStates: [AchievementState] {
+        AchievementEngine.evaluate(AchievementInput(
+            incomeTotal: lifetimeIncome,
             incomeCount: incomes.count,
             expenseCount: expenses.count,
             loggedDates: incomes.map(\.date) + expenses.map(\.date),
@@ -162,10 +180,125 @@ struct ProfileView: View {
             bestGoalProgress: goals.map(\.progress).max() ?? 0,
             completedGoalCount: goals.filter { $0.progress >= 1 }.count
         ))
-        return states.prefix(6).map { state in
-            state.unlocked
-                ? BadgePreview(icon: state.icon, bg: state.tileBackground, color: state.tileColor, unlocked: true)
-                : BadgePreview(icon: "lock.fill", bg: Color.warmBg, color: Color.warmInkMuted, unlocked: false)
+    }
+
+    private var unlockedAchievements: [AchievementState] { achievementStates.filter(\.unlocked) }
+
+    /// The locked achievement the user is closest to — one row with a real
+    /// bar beats a grid of padlocks on a fresh install.
+    private var nextAchievement: AchievementState? {
+        achievementStates.filter { !$0.unlocked }.max { $0.progress < $1.progress }
+    }
+
+    private var achievementsCard: some View {
+        VStack(spacing: 12) {
+            HStack {
+                Text("Achievements")
+                    .font(.system(size: 18, weight: .regular, design: .serif))
+                    .foregroundStyle(Color.warmInk)
+                Spacer()
+                Button(action: { showingAchievements = true }) {
+                    Text("See all ›")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(Color.warmGreen)
+                }
+            }
+
+            if !unlockedAchievements.isEmpty {
+                HStack(spacing: 10) {
+                    ForEach(unlockedAchievements.prefix(6)) { state in
+                        BadgeTile(icon: state.icon, bg: state.tileBackground, color: state.tileColor, unlocked: true)
+                            .accessibilityLabel(state.title)
+                    }
+                    if unlockedAchievements.count < 6 {
+                        Spacer(minLength: 0)
+                    }
+                }
+            }
+
+            if let next = nextAchievement {
+                NextAchievementRow(state: next)
+            } else {
+                Text(Strings.Profile.allAchievementsUnlockedLabel)
+                    .font(.system(size: 13))
+                    .foregroundStyle(Color.warmInkSoft)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .padding(16)
+        .background(Color.warmSurface)
+        .cornerRadius(20)
+        .overlay(RoundedRectangle(cornerRadius: 20).stroke(Color.warmLine, lineWidth: 1))
+    }
+
+    // MARK: - Settings
+
+    private var settingsSection: some View {
+        ProfileSection(header: "Settings") {
+            if viewModel.notificationsDenied {
+                NotificationsDeniedRow(onOpenSettings: {
+                    if let url = URL(string: UIApplication.openSettingsURLString) { openURL(url) }
+                })
+            } else {
+                SettingsToggleRow(
+                    icon: "bell.fill",
+                    title: Strings.Profile.expenseRemindersLabel,
+                    isOn: reminderEnabledBinding(.expense)
+                )
+                if viewModel.reminders.expenseEnabled {
+                    ReminderTimeRow(time: reminderTimeBinding(.expense))
+                }
+                WarmDivider()
+                SettingsToggleRow(
+                    icon: "target",
+                    title: Strings.Profile.goalAlertsLabel,
+                    isOn: reminderEnabledBinding(.goal)
+                )
+                if viewModel.reminders.goalEnabled {
+                    ReminderTimeRow(time: reminderTimeBinding(.goal))
+                }
+            }
+            if FeatureFlags.darkModeEnabled {
+                WarmDivider()
+                SettingsToggleRow(icon: "moon.fill", title: Strings.Profile.darkModeLabel, isOn: $viewModel.darkMode)
+            }
+        }
+    }
+
+    private func reminderEnabledBinding(_ kind: ReminderKind) -> Binding<Bool> {
+        Binding(
+            get: { viewModel.reminders.isEnabled(kind) },
+            set: { viewModel.setReminder(kind, enabled: $0) }
+        )
+    }
+
+    private func reminderTimeBinding(_ kind: ReminderKind) -> Binding<Date> {
+        Binding(
+            get: { viewModel.reminders.time(for: kind) },
+            set: { viewModel.setReminder(kind, time: $0) }
+        )
+    }
+
+    // MARK: - Data & privacy
+
+    private var dataPrivacySection: some View {
+        ProfileSection(header: Strings.Profile.dataPrivacyTitle) {
+            HStack(spacing: 16) {
+                Image(systemName: "lock.shield")
+                    .font(.system(size: 18))
+                    .foregroundStyle(Color.warmGreen)
+                    .frame(width: 28)
+                    .accessibilityHidden(true)
+                Text(Strings.Profile.dataStaysLocalLabel)
+                    .font(.system(size: 13))
+                    .foregroundStyle(Color.warmInkSoft)
+                Spacer()
+            }
+            .padding(.horizontal, 16).padding(.vertical, 14)
+            WarmDivider()
+            SettingsNavRow(icon: "doc.text.fill", title: "Weekly PDF report", onTap: { viewModel.generateWeeklyReportPDF() })
+            WarmDivider()
+            SettingsNavRow(icon: "trash", title: Strings.Profile.deleteAllDataLabel, color: Color.warmClay, onTap: { showingDeleteDialog = true })
         }
     }
 
@@ -173,6 +306,135 @@ struct ProfileView: View {
         let f = NumberFormatter()
         f.numberStyle = .currency; f.currencySymbol = "$"; f.maximumFractionDigits = 0
         return f.string(from: NSNumber(value: v)) ?? "$0"
+    }
+}
+
+// MARK: - Stat cell
+
+struct ProfileStatCell: View {
+    let label: String
+    let value: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(label)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(Color.warmInkMuted)
+                .tracking(0.8)
+                .textCase(.uppercase)
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+            Text(value)
+                .font(.system(size: 20, weight: .regular, design: .serif))
+                .foregroundStyle(Color.warmInk)
+                .monospacedDigit()
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.warmSurface)
+        .cornerRadius(16)
+        .overlay(RoundedRectangle(cornerRadius: 16).stroke(Color.warmLine, lineWidth: 1))
+        .accessibilityElement(children: .combine)
+    }
+}
+
+// MARK: - Next achievement row
+
+struct NextAchievementRow: View {
+    let state: AchievementState
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(Strings.Profile.nextAchievementLabel)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(Color.warmInkMuted)
+                .tracking(0.8)
+                .textCase(.uppercase)
+
+            HStack(spacing: 12) {
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(state.tileBackground)
+                    .frame(width: 36, height: 36)
+                    .overlay(Image(systemName: state.icon).font(.system(size: 15)).foregroundStyle(state.tileColor))
+                    .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(state.title)
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(Color.warmInk)
+                    Text(state.subtitle)
+                        .font(.system(size: 12))
+                        .foregroundStyle(Color.warmInkSoft)
+                    GeometryReader { geo in
+                        ZStack(alignment: .leading) {
+                            Capsule().fill(Color.warmGreenSoft).frame(height: 4)
+                            Capsule().fill(Color.warmGreen)
+                                .frame(width: geo.size.width * state.progress, height: 4)
+                        }
+                    }
+                    .frame(height: 4)
+                    .padding(.top, 2)
+                }
+                Spacer()
+                Text("\(Int(state.progress * 100))%")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(Color.warmInkSoft)
+                    .monospacedDigit()
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityValue("\(Int(state.progress * 100)) percent")
+    }
+}
+
+// MARK: - Notifications denied row
+
+struct NotificationsDeniedRow: View {
+    let onOpenSettings: () -> Void
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 16) {
+            Image(systemName: "bell.slash")
+                .font(.system(size: 18))
+                .foregroundStyle(Color.warmInkSoft)
+                .frame(width: 28)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 6) {
+                Text(Strings.Profile.notificationsDeniedHint)
+                    .font(.system(size: 13))
+                    .foregroundStyle(Color.warmInkSoft)
+                    .fixedSize(horizontal: false, vertical: true)
+                Button(action: onOpenSettings) {
+                    Text(Strings.Profile.openSettingsButton)
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(Color.warmGreen)
+                }
+            }
+            Spacer()
+        }
+        .padding(.horizontal, 16).padding(.vertical, 14)
+    }
+}
+
+// MARK: - Reminder time row
+
+struct ReminderTimeRow: View {
+    @Binding var time: Date
+
+    var body: some View {
+        HStack(spacing: 16) {
+            Color.clear.frame(width: 28)
+            Text(Strings.Profile.reminderTimeLabel)
+                .font(.system(size: 14))
+                .foregroundStyle(Color.warmInkSoft)
+            Spacer()
+            DatePicker(Strings.Profile.reminderTimeLabel, selection: $time, displayedComponents: .hourAndMinute)
+                .labelsHidden()
+                .tint(Color.warmGreen)
+        }
+        .padding(.horizontal, 16).padding(.bottom, 12)
     }
 }
 
@@ -202,6 +464,7 @@ struct ProfileSection<Content: View>: View {
                 .foregroundStyle(Color.warmInkMuted)
                 .tracking(0.8)
                 .padding(.leading, 4)
+                .accessibilityAddTraits(.isHeader)
             VStack(spacing: 0) { content() }
                 .background(Color.warmSurface)
                 .cornerRadius(16)
@@ -218,6 +481,8 @@ struct WarmDivider: View {
 
 // MARK: - Settings rows (redesigned)
 
+/// The `Toggle` owns the title so VoiceOver reads
+/// "<title>, switch, on" — never `Toggle("")`.
 struct SettingsToggleRow: View {
     let icon: String
     let title: String
@@ -228,9 +493,11 @@ struct SettingsToggleRow: View {
                 .font(.system(size: 18))
                 .foregroundStyle(Color.warmInkSoft)
                 .frame(width: 28)
-            Text(title).font(.system(size: 14, weight: .medium)).foregroundStyle(Color.warmInk)
-            Spacer()
-            Toggle("", isOn: $isOn).labelsHidden().tint(Color.warmGreen)
+                .accessibilityHidden(true)
+            Toggle(isOn: $isOn) {
+                Text(title).font(.system(size: 14, weight: .medium)).foregroundStyle(Color.warmInk)
+            }
+            .tint(Color.warmGreen)
         }
         .padding(.horizontal, 16).padding(.vertical, 14)
     }
@@ -293,4 +560,7 @@ struct InnerHeightPreferenceKey: PreferenceKey {
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) { value = nextValue() }
 }
 
-#Preview { ProfileView() }
+#Preview {
+    NavigationStack { ProfileView() }
+        .environmentObject(AppViewModel())
+}

--- a/SavelyTests/ReminderSettingsTests.swift
+++ b/SavelyTests/ReminderSettingsTests.swift
@@ -1,0 +1,75 @@
+//
+//  ReminderSettingsTests.swift
+//  SavelyTests
+//
+
+import XCTest
+@testable import Savely
+
+final class ReminderSettingsTests: XCTestCase {
+    private let calendar = Calendar(identifier: .gregorian)
+    private let now = Date(timeIntervalSince1970: 1_784_000_000)
+
+    // MARK: - Planner
+
+    func testEnabledReminderIsScheduledAtItsTime() {
+        let time = Date(timeIntervalSince1970: 1_000)
+        XCTAssertEqual(ReminderPlanner.action(enabled: true, time: time), .schedule(at: time))
+    }
+
+    func testDisabledReminderIsCancelled() {
+        XCTAssertEqual(ReminderPlanner.action(enabled: false, time: now), .cancel)
+    }
+
+    func testActionsCoverBothKindsIndependently() {
+        var prefs = ReminderPreferences.defaults(calendar: calendar, now: now)
+        prefs.expenseEnabled = false
+        let actions = ReminderPlanner.actions(for: prefs)
+        XCTAssertEqual(actions[.expense], .cancel)
+        XCTAssertEqual(actions[.goal], .schedule(at: prefs.goalTime))
+    }
+
+    // MARK: - Identifiers (must never change — they address pending requests)
+
+    func testIdentifiersMatchTheOnesShippedSinceV1() {
+        XCTAssertEqual(ReminderKind.expense.rawValue, "expenseReminder")
+        XCTAssertEqual(ReminderKind.goal.rawValue, "goalAlert")
+    }
+
+    // MARK: - Defaults
+
+    func testDefaultsAreBothOnEveningAndMorning() {
+        let prefs = ReminderPreferences.defaults(calendar: calendar, now: now)
+        XCTAssertTrue(prefs.expenseEnabled)
+        XCTAssertTrue(prefs.goalEnabled)
+        XCTAssertEqual(calendar.component(.hour, from: prefs.expenseTime), 20)
+        XCTAssertEqual(calendar.component(.hour, from: prefs.goalTime), 9)
+    }
+
+    // MARK: - Store
+
+    private func freshDefaults() throws -> UserDefaults {
+        let name = "ReminderSettingsTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: name))
+        defaults.removePersistentDomain(forName: name)
+        return defaults
+    }
+
+    func testStoreReportsNothingSavedOnFreshInstall() throws {
+        let store = ReminderStore(defaults: try freshDefaults())
+        XCTAssertFalse(store.hasSavedPreferences)
+        XCTAssertEqual(store.load(), ReminderPreferences.defaults())
+    }
+
+    func testStoreRoundTripsEveryField() throws {
+        let store = ReminderStore(defaults: try freshDefaults())
+        let saved = ReminderPreferences(
+            expenseEnabled: false, goalEnabled: true,
+            expenseTime: Date(timeIntervalSince1970: 3_600),
+            goalTime: Date(timeIntervalSince1970: 7_200)
+        )
+        store.save(saved)
+        XCTAssertTrue(store.hasSavedPreferences)
+        XCTAssertEqual(store.load(), saved)
+    }
+}

--- a/docs/plans/pr-d2-adaptive-palette.md
+++ b/docs/plans/pr-d2-adaptive-palette.md
@@ -115,8 +115,31 @@ Note `green` splits into *text/icon* (lightened for dark) and *fill*
 white text; only green *as ink* brightens. That is what keeps dark from
 reading as a different brand.
 
+## Also in this PR (owner's request, 2026-08-16): drop the "User" identity
+
+There is no account, so the monogram + "User" card on Profile and the
+`person.fill` circle in the Dashboard greeting (`DashboardView.swift:~63-71`)
+are placeholders for an identity the app deliberately does not have.
+Remove both:
+
+- **Profile:** delete the identity card. Move its one useful line —
+  "Saving since <month>" / "Just getting started" — into the lifetime
+  income card as its subtitle (replacing "Total income logged in Savely").
+- **Dashboard:** delete the amber `person.fill` circle from the greeting
+  row; the greeting keeps its date + "Evening." only.
+- **Display name:** with the card gone nothing reaches `EditProfileSheet`.
+  Delete the sheet, `ProfileViewModel.displayName` /
+  `updatePersonalInformation()`, and `AppViewModel.currentUserName` +
+  its `"displayName"` UserDefaults key. Also drop the now-unused
+  `Strings.Profile.editNameHint` and its catalog entry. Confirm nothing
+  else reads `"displayName"` (grep) before deleting.
+
+Sequenced as its own commit (commit 0 below) so it can be reverted alone.
+
 ## Commits
 
+0. **Drop the identity placeholders** (Profile card, Dashboard avatar,
+   display-name plumbing) as described above.
 1. **Palette:** dynamic-color helper + all 18 tokens get a dark value + the
    new role tokens. Build must be green with **no call-site changes** yet.
 2. **Sweep the hardcodes:** route the 97 sites through tokens, screen by


### PR DESCRIPTION
## Summary
Executes `docs/plans/pr-d-profile.md`.

- **Reminder settings are real, two-way and persisted.** New `Savely/Utilities/ReminderSettings.swift`: `ReminderKind` (the two `UNNotificationRequest` identifiers, unchanged since v1 — unit-tested so they never drift), `ReminderPreferences`, `ReminderPlanner` (the pure schedule/cancel decision), `ReminderStore` (explicit `UserDefaults`, **not** `@AppStorage` inside the `ObservableObject` — that was the re-render trap). `NotificationManager` gains `apply(_:to:)`, `authorizationStatus()` and `pendingReminderTime(for:)`.
- **Onboarding** notifications step gets a per-reminder opt-out + time and writes the same store the Profile reads, so the two can never disagree. Finishing onboarding schedules only what was left on.
- **Migration** for installs that onboarded before preferences existed: on first Profile visit the times are seeded once from the still-pending requests (a missing request means the old one-way toggle turned it off).
- **Profile tab** (`ProfileView.swift`): dead bell removed; nested `NavigationStack` removed; identity card is the edit affordance and says "Saving since <month>" / "Just getting started"; stats strip (saved · movements · active goals); the **next** achievement as a row with a real progress bar instead of six padlocks (unlocked ones stay as tiles); Settings shows both reminders with editable times — or, when iOS permission is denied, a hint + **Open Settings** instead of a dead switch; new **Data & privacy** section (local-first line, Weekly PDF, **Delete all data** with a two-step confirm).
- **VoiceOver on what this PR touches:** every `Toggle` owns its title (no more `Toggle("")`), decorative tiles hidden, rows combined, section headers carry `.isHeader`.
- **Dark Mode row hidden** behind `FeatureFlags.darkModeEnabled = false` until PR D2 flips it; the `@AppStorage`/`preferredColorScheme` plumbing stays.
- Strings: all new copy through `Strings.swift` **with es-419** in the catalog; the two onboarding time-label keys this change orphaned are removed.
- Docs: `pr-d2-adaptive-palette.md` gains commit 0 — remove the placeholder "User" identity card and the Dashboard avatar (owner's request during review).

## Why
Verified live before this PR: the Notifications toggle only ever *cancelled* (console showed `cancelled` on off and nothing on on), reset to "on" every launch while the reminder stayed cancelled, `goalAlert` could never be turned off, reminder times were `@State` used once and stored nowhere, the bell was `Button(action: {})`, and Dark Mode persisted but changed nothing (palette is light-only → D2). Full evidence table in the plan.

## Test plan
- [x] `xcodebuild build` — BUILD SUCCEEDED
- [x] `xcodebuild test -skip-testing:SavelyUITests` — TEST SUCCEEDED (7 new `ReminderSettingsTests`: planner both ways, identifiers pinned, defaults, store round-trip)
- [x] `swiftlint lint --strict` — 0
- [x] `plutil -lint project.pbxproj` OK; catalog JSON valid, 289 keys, every new key has en + es-419
- [ ] **Simulator walk-through NOT completed by me** — the Claude Code simulator panel crashed mid-session and its own error said retrying would not help. Please verify (or re-open the panel and I will):
  - fresh install → onboarding last step shows two toggles + times; turn one off → after Start, console shows one `Scheduled` and no request for the other
  - Profile → toggle off → console `cancelled`; toggle on → console `Scheduled`; change time → `Scheduled` again; relaunch → state persists
  - deny notification permission in iOS Settings → Profile shows the hint + Open Settings, no switches
  - fresh-install Profile looks deliberate; populated shows stats + "Next up" bar
  - Delete all data → two confirms → dashboard empty; name + reminder settings kept
  - VoiceOver: "Expense Reminders, switch, on"; identity card reads name + hint
  - **tap the toggles with a finger** (harness flipped them on drag, not tap — likely an artifact)

## Risks
- Behavior change: users who had turned the old toggle off get `expenseEnabled = false` seeded (no pending request) — matches what they actually had.
- `deleteAllData()` uses `modelContext.delete(model:)` on all four models; keeps name + reminders on purpose (dialog says so).
- `Toggle` now renders its own label (was `Toggle("")` + separate `Text`); layout is the same HStack, worth an eyeball.

## Checklist
- [x] `feat/` branch, Conventional Commits, no AI attribution
- [x] New user-facing strings through `Strings.swift` + catalog (en + es-419)
- [x] No secrets staged
- [x] Tests added for behavior changes
- [x] `CLAUDE.md`: no new invariant