### PR TITLE
feat: real expense categories and income sources

### DIFF
--- a/Savely.xcodeproj/project.pbxproj
+++ b/Savely.xcodeproj/project.pbxproj
@@ -11,7 +11,9 @@
 		DE826483AC71FF3EC2A603B7 /* AutoMoveSuggestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = F774124079B5BEC3DD37C743 /* AutoMoveSuggestion.swift */; };
 		A11A0002C0DE5AFE10000002 /* AmountParsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A0001C0DE5AFE10000001 /* AmountParsing.swift */; };
 		A11A0006C0DE5AFE10000006 /* ReminderSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A0005C0DE5AFE10000005 /* ReminderSettings.swift */; };
+		A11A000CC0DE5AFE1000000C /* MoneyCategories.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A000BC0DE5AFE1000000B /* MoneyCategories.swift */; };
 		A11A0008C0DE5AFE10000008 /* ReminderSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A0007C0DE5AFE10000007 /* ReminderSettingsTests.swift */; };
+		A11A000EC0DE5AFE1000000E /* CategoryPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A000DC0DE5AFE1000000D /* CategoryPersistenceTests.swift */; };
 		A11A0004C0DE5AFE10000004 /* AmountParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A0003C0DE5AFE10000003 /* AmountParsingTests.swift */; };
 		510740529955B0B1E6EA730D /* AchievementEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62FA742D1E24F010F3273E30 /* AchievementEngineTests.swift */; };
 		F764EBD092BA4435466DD9AA /* AchievementEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12789AD27FF1A7114156F945 /* AchievementEngine.swift */; };
@@ -100,7 +102,9 @@
 		F774124079B5BEC3DD37C743 /* AutoMoveSuggestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoMoveSuggestion.swift; sourceTree = "<group>"; };
 		A11A0001C0DE5AFE10000001 /* AmountParsing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmountParsing.swift; sourceTree = "<group>"; };
 		A11A0005C0DE5AFE10000005 /* ReminderSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderSettings.swift; sourceTree = "<group>"; };
+		A11A000BC0DE5AFE1000000B /* MoneyCategories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoneyCategories.swift; sourceTree = "<group>"; };
 		A11A0007C0DE5AFE10000007 /* ReminderSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderSettingsTests.swift; sourceTree = "<group>"; };
+		A11A000DC0DE5AFE1000000D /* CategoryPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryPersistenceTests.swift; sourceTree = "<group>"; };
 		A11A0003C0DE5AFE10000003 /* AmountParsingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmountParsingTests.swift; sourceTree = "<group>"; };
 		62FA742D1E24F010F3273E30 /* AchievementEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchievementEngineTests.swift; sourceTree = "<group>"; };
 		12789AD27FF1A7114156F945 /* AchievementEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchievementEngine.swift; sourceTree = "<group>"; };
@@ -246,6 +250,7 @@
 				F774124079B5BEC3DD37C743 /* AutoMoveSuggestion.swift */,
 				A11A0001C0DE5AFE10000001 /* AmountParsing.swift */,
 				A11A0005C0DE5AFE10000005 /* ReminderSettings.swift */,
+				A11A000BC0DE5AFE1000000B /* MoneyCategories.swift */,
 				12789AD27FF1A7114156F945 /* AchievementEngine.swift */,
 				693B815A380D566280140319 /* FeatureFlags.swift */,
 				1DE9FE162D066EE20069AA64 /* ReportsPDFGenerator.swift */,
@@ -443,6 +448,7 @@
 				9AFC2151C01A7FBD2947EB51 /* AutoMoveSuggestionTests.swift */,
 				A11A0003C0DE5AFE10000003 /* AmountParsingTests.swift */,
 				A11A0007C0DE5AFE10000007 /* ReminderSettingsTests.swift */,
+				A11A000DC0DE5AFE1000000D /* CategoryPersistenceTests.swift */,
 				62FA742D1E24F010F3273E30 /* AchievementEngineTests.swift */,
 				1DC258182CC07DCF0002DDE3 /* SavelyTests.swift */,
 			);
@@ -669,6 +675,7 @@
 				DE826483AC71FF3EC2A603B7 /* AutoMoveSuggestion.swift in Sources */,
 				A11A0002C0DE5AFE10000002 /* AmountParsing.swift in Sources */,
 				A11A0006C0DE5AFE10000006 /* ReminderSettings.swift in Sources */,
+				A11A000CC0DE5AFE1000000C /* MoneyCategories.swift in Sources */,
 				F764EBD092BA4435466DD9AA /* AchievementEngine.swift in Sources */,
 				ED04D2F84390584EB7EC0615 /* WelcomeStepView.swift in Sources */,
 				699FCB7F699B1E9C9C644AF3 /* SproutMark.swift in Sources */,
@@ -723,6 +730,7 @@
 				AA28B8C8B38F312A7623F2D2 /* AutoMoveSuggestionTests.swift in Sources */,
 				A11A0004C0DE5AFE10000004 /* AmountParsingTests.swift in Sources */,
 				A11A0008C0DE5AFE10000008 /* ReminderSettingsTests.swift in Sources */,
+				A11A000EC0DE5AFE1000000E /* CategoryPersistenceTests.swift in Sources */,
 				510740529955B0B1E6EA730D /* AchievementEngineTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Savely/Models/ExpenseModel.swift
+++ b/Savely/Models/ExpenseModel.swift
@@ -14,12 +14,18 @@ class ExpenseModel {
     var expenseDescription: String
     var amount: Double
     var date: Date
+    /// The chip the user picked when logging ("Coffee", "Food", "Transit",
+    /// "Shopping", "Other"). `nil` for rows logged before categories were
+    /// stored and for scanned receipts — display then falls back to keyword
+    /// inference, but the guess is never written back here.
+    var category: String?
 
-    init(expenseDescription: String, amount: Double, date: Date) {
+    init(expenseDescription: String, amount: Double, date: Date, category: String? = nil) {
         self.id = UUID()
         self.expenseDescription = expenseDescription
         self.amount = amount
         self.date = date
+        self.category = category
     }
 }
 

--- a/Savely/Models/IncomeModel.swift
+++ b/Savely/Models/IncomeModel.swift
@@ -14,12 +14,17 @@ class IncomeModel {
     var incomeDescription: String
     var amount: Double
     var date: Date
+    /// The source chip the user picked when logging ("Paycheck",
+    /// "Freelance", "Gift", "Other"). `nil` for rows logged before sources
+    /// were stored.
+    var source: String?
 
-    init(incomeDescription: String, amount: Double, date: Date) {
+    init(incomeDescription: String, amount: Double, date: Date, source: String? = nil) {
         self.id = UUID()
         self.incomeDescription = incomeDescription
         self.amount = amount
         self.date = date
+        self.source = source
     }
 }
 

--- a/Savely/Utilities/MoneyCategories.swift
+++ b/Savely/Utilities/MoneyCategories.swift
@@ -1,0 +1,99 @@
+//
+//  MoneyCategories.swift
+//  Savely
+//
+//  The canonical expense categories and income sources — the chips the
+//  quick-add sheets show, the values stored on the models, and the one
+//  place their icon/tile pairing lives. Also the legacy keyword inference
+//  used only for rows that predate stored categories.
+//
+
+import SwiftUI
+
+/// The five expense chips. `rawValue` is exactly what `ExpenseModel.category`
+/// stores, so renaming a case is a data migration — don't.
+enum ExpenseCategory: String, CaseIterable, Identifiable {
+    case coffee = "Coffee"
+    case food = "Food"
+    case transit = "Transit"
+    case shopping = "Shopping"
+    case other = "Other"
+
+    var id: String { rawValue }
+    var label: String { rawValue }
+
+    var icon: String {
+        switch self {
+        case .coffee: return "cup.and.saucer.fill"
+        case .food: return "fork.knife"
+        case .transit: return "car.fill"
+        case .shopping: return "bag.fill"
+        case .other: return "creditcard"
+        }
+    }
+
+    var tileBackground: Color {
+        switch self {
+        case .coffee: return .warmAmberSoft
+        case .food: return .warmGreenSoft
+        case .transit: return .warmSkySoft
+        case .shopping: return .warmClaySoft
+        case .other: return .warmBg
+        }
+    }
+
+    var tileColor: Color {
+        switch self {
+        case .coffee: return .warmAmber
+        case .food: return .warmGreen
+        case .transit: return .warmSky
+        case .shopping: return .warmClay
+        case .other: return .warmInkMuted
+        }
+    }
+
+    /// The category to *show* for a row: the stored chip when there is one,
+    /// otherwise a keyword guess. The guess is display-only — it is never
+    /// written back to the store.
+    static func display(stored: String?, description: String) -> ExpenseCategory {
+        if let stored, let known = ExpenseCategory(rawValue: stored) { return known }
+        return legacyInferred(from: description)
+    }
+
+    /// The pre-categories heuristic the Money tab used to run on every row.
+    /// Kept only for rows logged before `ExpenseModel.category` existed.
+    static func legacyInferred(from description: String) -> ExpenseCategory {
+        let d = description.lowercased()
+        if d.contains("coffee") || d.contains("cafe") { return .coffee }
+        if d.contains("grocery") || d.contains("groceries") || d.contains("whole foods")
+            || d.contains("restaurant") || d.contains("food") { return .food }
+        if d.contains("uber") || d.contains("lyft") || d.contains("transit") || d.contains("muni") { return .transit }
+        return .other
+    }
+}
+
+/// The four income chips. `rawValue` is what `IncomeModel.source` stores.
+enum IncomeSource: String, CaseIterable, Identifiable {
+    case paycheck = "Paycheck"
+    case freelance = "Freelance"
+    case gift = "Gift"
+    case other = "Other"
+
+    var id: String { rawValue }
+    var label: String { rawValue }
+
+    var icon: String {
+        switch self {
+        case .paycheck: return "building.columns"
+        case .freelance: return "laptopcomputer"
+        case .gift: return "gift"
+        case .other: return "arrow.up"
+        }
+    }
+
+    /// Nil when nothing was stored — legacy income rows show no source tag
+    /// rather than a guessed one.
+    static func display(stored: String?) -> IncomeSource? {
+        stored.flatMap(IncomeSource.init(rawValue:))
+    }
+}

--- a/Savely/ViewModels/ExpensesTab/ExpensesTrackerViewModel.swift
+++ b/Savely/ViewModels/ExpensesTab/ExpensesTrackerViewModel.swift
@@ -63,7 +63,10 @@ class ExpenseTrackerViewModel: ObservableObject {
         }
     }
 
-    func addExpense() {
+    /// - Parameter category: the chip picked in the quick-add sheet. The
+    ///   inline Money-tab form and the receipt scanner pass nothing — their
+    ///   rows display through keyword inference instead.
+    func addExpense(category: String? = nil) {
         guard let modelContext = modelContext else { return }
         guard let amountValue = parseAmount(amount) else {
             // Used to return silently, so a typo just did nothing at all.
@@ -75,7 +78,8 @@ class ExpenseTrackerViewModel: ObservableObject {
         let newExpense = ExpenseModel(
             expenseDescription: expenseDescription,
             amount: amountValue,
-            date: Date()
+            date: Date(),
+            category: category
         )
         modelContext.insert(newExpense)
 

--- a/Savely/ViewModels/IncomesTab/IncomesTrackerViewModel.swift
+++ b/Savely/ViewModels/IncomesTab/IncomesTrackerViewModel.swift
@@ -100,7 +100,9 @@ class IncomesTrackerViewModel: ObservableObject {
         }
     }
 
-    func addIncome() {
+    /// - Parameter source: the chip picked in the quick-add sheet; the inline
+    ///   Money-tab form passes nothing.
+    func addIncome(source: String? = nil) {
         guard let modelContext = modelContext else { return }
         guard let amountValue = parseAmount(amount) else {
             // Used to return silently, so a typo just did nothing at all.
@@ -112,7 +114,8 @@ class IncomesTrackerViewModel: ObservableObject {
         let newIncome = IncomeModel(
             incomeDescription: incomeDescription,
             amount: amountValue,
-            date: Date()
+            date: Date(),
+            source: source
         )
         modelContext.insert(newIncome)
 

--- a/Savely/Views/DashboardTab/ReportsView.swift
+++ b/Savely/Views/DashboardTab/ReportsView.swift
@@ -9,103 +9,170 @@ import SwiftUI
 import Charts
 import SwiftData
 
+/// Income by source and expenses by category over a date range. Reachable
+/// from Profile → Reports. Groups by the *stored* chip (legacy rows fall
+/// back to the same keyword inference the Money tab uses), so the bars
+/// finally mean something.
 struct ReportsView: View {
     @Environment(\.modelContext) private var modelContext
-    @StateObject private var viewModel: ReportsViewModel
+    @StateObject private var viewModel = ReportsViewModel()
 
-    init() {
-        _viewModel = StateObject(wrappedValue: ReportsViewModel(modelContext: Environment(\.modelContext).wrappedValue))
+    private struct Slice: Identifiable {
+        let label: String
+        let amount: Double
+        var id: String { label }
+    }
+
+    private var incomeBySource: [Slice] {
+        var totals: [String: Double] = [:]
+        for income in viewModel.weeklyIncomes {
+            let key = IncomeSource.display(stored: income.source)?.label ?? "Untagged"
+            totals[key, default: 0] += income.amount
+        }
+        return totals.map { Slice(label: $0.key, amount: $0.value) }.sorted { $0.amount > $1.amount }
+    }
+
+    private var expensesByCategory: [Slice] {
+        var totals: [String: Double] = [:]
+        for expense in viewModel.weeklyExpenses {
+            let key = ExpenseCategory.display(stored: expense.category, description: expense.expenseDescription).label
+            totals[key, default: 0] += expense.amount
+        }
+        return totals.map { Slice(label: $0.key, amount: $0.value) }.sorted { $0.amount > $1.amount }
+    }
+
+    private var expenseColorScale: KeyValuePairs<String, Color> {
+        KeyValuePairs(dictionaryLiteral:
+            (ExpenseCategory.coffee.label, ExpenseCategory.coffee.tileColor),
+            (ExpenseCategory.food.label, ExpenseCategory.food.tileColor),
+            (ExpenseCategory.transit.label, ExpenseCategory.transit.tileColor),
+            (ExpenseCategory.shopping.label, ExpenseCategory.shopping.tileColor),
+            (ExpenseCategory.other.label, ExpenseCategory.other.tileColor)
+        )
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 20) {
-            // Date Picker
-            VStack(alignment: .leading, spacing: 15) {
-                Text(Strings.Profile.weeklyReportTitle)
-                    .font(.title)
-                    .fontWeight(.bold)
-
-                VStack {
-                    DatePicker(Strings.ReportsView.startDateLabel, selection: $viewModel.startDate, displayedComponents: .date)
-                    DatePicker(Strings.ReportsView.endDateLabel, selection: $viewModel.endDate, displayedComponents: .date)
+        ScrollView {
+            VStack(spacing: 14) {
+                // — Header —
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Reports")
+                        .font(.system(size: 34, weight: .regular, design: .serif))
+                        .foregroundStyle(Color.warmInk)
+                    Text(rangeSubtitle)
+                        .font(.system(size: 13))
+                        .foregroundStyle(Color.warmInkMuted)
                 }
-                
-                HStack {
-                    Spacer()
-                    Button(action: viewModel.fetchReportData) {
-                        if viewModel.isLoading {
-                            ProgressView()
-                                .progressViewStyle(CircularProgressViewStyle())
-                        } else {
-                            Text(Strings.Buttons.fetchReportButton)
-                                .fontWeight(.bold)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.top, 8)
+
+                // — Range —
+                VStack(spacing: 0) {
+                    dateRow(Strings.ReportsView.startDateLabel, selection: $viewModel.startDate)
+                    WarmDivider()
+                    dateRow(Strings.ReportsView.endDateLabel, selection: $viewModel.endDate)
+                }
+                .background(Color.warmSurface)
+                .cornerRadius(16)
+                .overlay(RoundedRectangle(cornerRadius: 16).stroke(Color.warmLine, lineWidth: 1))
+
+                if viewModel.isLoading {
+                    ProgressView().tint(Color.warmGreen).padding(.vertical, 8)
+                }
+
+                // — Income by source —
+                if !incomeBySource.isEmpty {
+                    chartCard(title: Strings.ReportsView.incomeDistributionLabel) {
+                        Chart(incomeBySource) { slice in
+                            BarMark(
+                                x: .value("Amount", slice.amount),
+                                y: .value("Source", slice.label)
+                            )
+                            .foregroundStyle(Color.warmGreen)
+                            .cornerRadius(4)
                         }
+                        .chartXAxis { AxisMarks(position: .bottom) { AxisValueLabel(format: .currency(code: "USD").precision(.fractionLength(0))) } }
+                        .frame(height: CGFloat(28 * incomeBySource.count + 40))
                     }
-                    .padding()
-                    .background(Color.warmSky)
-                    .foregroundColor(Color.warmOnGreen)
-                    .cornerRadius(UIConstants.UICornerRadius.cornerRadius)
-                    Spacer()
                 }
-            }
 
-            // Income Chart
-            if !viewModel.weeklyIncomes.isEmpty {
-                VStack(alignment: .leading, spacing: 10) {
-                    Text(Strings.ReportsView.incomeDistributionLabel)
-                        .font(.title3)
-                        .fontWeight(.bold)
-
-                    Chart(viewModel.weeklyIncomes) { income in
-                        BarMark(
-                            x: .value(Strings.ExpenseTrackerTab.descriptionPlaceholderLabel, income.incomeDescription),
-                            y: .value(Strings.ExpenseTrackerTab.amountPlaceholderLabel, income.amount)
-                        )
+                // — Expenses by category —
+                if !expensesByCategory.isEmpty {
+                    chartCard(title: Strings.ReportsView.expenseDistributionLabel) {
+                        Chart(expensesByCategory) { slice in
+                            BarMark(
+                                x: .value("Amount", slice.amount),
+                                y: .value("Category", slice.label)
+                            )
+                            .foregroundStyle(by: .value("Category", slice.label))
+                            .cornerRadius(4)
+                        }
+                        .chartForegroundStyleScale(expenseColorScale)
+                        .chartLegend(.hidden)
+                        .chartXAxis { AxisMarks(position: .bottom) { AxisValueLabel(format: .currency(code: "USD").precision(.fractionLength(0))) } }
+                        .frame(height: CGFloat(28 * expensesByCategory.count + 40))
                     }
-                    .frame(height: 200)
                 }
-            }
 
-            // Expense Chart
-            if !viewModel.weeklyExpenses.isEmpty {
-                VStack(alignment: .leading, spacing: 10) {
-                    Text(Strings.ReportsView.expenseDistributionLabel)
-                        .font(.title3)
-                        .fontWeight(.bold)
-
-                    Chart(viewModel.weeklyExpenses) { expense in
-                        SectorMark(
-                            angle: .value(Strings.ExpenseTrackerTab.amountPlaceholderLabel, expense.amount),
-                            innerRadius: .ratio(0.5),
-                            outerRadius: .ratio(1.0)
-                        )
-                        .foregroundStyle(by: .value(Strings.ExpenseTrackerTab.descriptionPlaceholderLabel, expense.expenseDescription))
+                if !viewModel.isLoading && incomeBySource.isEmpty && expensesByCategory.isEmpty {
+                    VStack(spacing: 10) {
+                        Image(systemName: "chart.bar").font(.system(size: 36)).foregroundStyle(Color.warmInkMuted)
+                        Text(Strings.ReportsView.noDataLabel)
+                            .font(.system(size: 14))
+                            .foregroundStyle(Color.warmInkSoft)
+                            .multilineTextAlignment(.center)
                     }
-                    .frame(height: 200)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 40)
                 }
-            }
 
-            if viewModel.weeklyIncomes.isEmpty && viewModel.weeklyExpenses.isEmpty {
-                Text(Strings.ReportsView.noDataLabel)
-                    .font(.callout)
-                    .foregroundColor(.gray)
-                    .frame(maxWidth: .infinity, alignment: .center)
+                Spacer(minLength: 16)
             }
+            .padding(.horizontal, 20)
+            .padding(.bottom, 24)
         }
-        .padding()
+        .background(Color.warmBg)
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear { viewModel.setModelContext(modelContext) }
+        .onChange(of: viewModel.startDate) { viewModel.fetchReportData() }
+        .onChange(of: viewModel.endDate) { viewModel.fetchReportData() }
+    }
+
+    private var rangeSubtitle: String {
+        let f = DateFormatter(); f.dateFormat = "MMM d"
+        return "\(f.string(from: viewModel.startDate)) – \(f.string(from: viewModel.endDate))"
+    }
+
+    private func dateRow(_ title: String, selection: Binding<Date>) -> some View {
+        HStack(spacing: 16) {
+            Text(title)
+                .font(.system(size: 14, weight: .medium))
+                .foregroundStyle(Color.warmInk)
+            Spacer()
+            DatePicker(title, selection: selection, displayedComponents: .date)
+                .labelsHidden()
+                .tint(Color.warmGreen)
+        }
+        .padding(.horizontal, 16).padding(.vertical, 10)
+    }
+
+    private func chartCard<Content: View>(title: String, @ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(title)
+                .font(.system(size: 18, weight: .regular, design: .serif))
+                .foregroundStyle(Color.warmInk)
+            content()
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .background(Color.warmSurface)
-        .cornerRadius(UIConstants.UICornerRadius.cornerRadiusMedium)
-        .onAppear {
-            viewModel.setModelContext(modelContext)
-            viewModel.fetchReportData()
-        }
+        .cornerRadius(20)
+        .overlay(RoundedRectangle(cornerRadius: 20).stroke(Color.warmLine, lineWidth: 1))
     }
 }
 
-struct ReportsView_Previews: PreviewProvider {
-    static var previews: some View {
-        ReportsView()
-    }
+#Preview {
+    NavigationStack { ReportsView() }
 }
 
 extension Calendar {

--- a/Savely/Views/ExpensesTab/ExpenseTrackerView.swift
+++ b/Savely/Views/ExpensesTab/ExpenseTrackerView.swift
@@ -229,34 +229,14 @@ struct ExpenseRowWarm: View {
         } message: { Text("Are you sure you want to delete this expense?") }
     }
 
-    private var expenseIcon: String {
-        let d = expense.expenseDescription.lowercased()
-        if d.contains("coffee") || d.contains("cafe") { return "cup.and.saucer.fill" }
-        if d.contains("grocery") || d.contains("groceries") || d.contains("whole foods") { return "cart.fill" }
-        if d.contains("uber") || d.contains("lyft") || d.contains("transit") || d.contains("muni") { return "car.fill" }
-        if d.contains("movie") || d.contains("entertainment") { return "tv.fill" }
-        if d.contains("restaurant") || d.contains("food") { return "fork.knife" }
-        return "creditcard.fill"
+    /// Stored chip first; keyword inference only for rows that predate it.
+    private var category: ExpenseCategory {
+        ExpenseCategory.display(stored: expense.category, description: expense.expenseDescription)
     }
-    private var iconBg: Color {
-        let d = expense.expenseDescription.lowercased()
-        if d.contains("coffee") || d.contains("cafe") { return Color.warmAmberSoft }
-        if d.contains("grocery") || d.contains("whole foods") { return Color.warmGreenSoft }
-        return Color.warmClaySoft
-    }
-    private var iconColor: Color {
-        let d = expense.expenseDescription.lowercased()
-        if d.contains("coffee") || d.contains("cafe") { return Color.warmAmber }
-        if d.contains("grocery") || d.contains("whole foods") { return Color.warmGreen }
-        return Color.warmClay
-    }
-    private var categoryLabel: String {
-        let d = expense.expenseDescription.lowercased()
-        if d.contains("coffee") || d.contains("cafe") { return "Coffee" }
-        if d.contains("grocery") || d.contains("groceries") { return "Groceries" }
-        if d.contains("uber") || d.contains("lyft") || d.contains("muni") { return "Transit" }
-        return "Expense"
-    }
+    private var expenseIcon: String { category.icon }
+    private var iconBg: Color { category.tileBackground }
+    private var iconColor: Color { category.tileColor }
+    private var categoryLabel: String { category.label }
     private func formattedAmount(_ v: Double) -> String {
         let f = NumberFormatter(); f.numberStyle = .currency; f.currencySymbol = "$"; f.maximumFractionDigits = 2
         return f.string(from: NSNumber(value: v)) ?? "$0"

--- a/Savely/Views/IncomesTab/IncomesTrackerView.swift
+++ b/Savely/Views/IncomesTab/IncomesTrackerView.swift
@@ -180,18 +180,26 @@ struct IncomeRowWarm: View {
     let onDelete: () -> Void
     @State private var showDeleteConfirmation = false
 
+    /// Stored source, if any. Legacy rows (nil) keep the plain arrow and
+    /// show no tag — a guessed source would be a lie.
+    private var source: IncomeSource? { IncomeSource.display(stored: income.source) }
+
     var body: some View {
         HStack(spacing: 12) {
             RoundedRectangle(cornerRadius: 10)
                 .fill(Color.warmGreenSoft)
                 .frame(width: 36, height: 36)
-                .overlay(Image(systemName: "arrow.up").font(.system(size: 14, weight: .medium)).foregroundStyle(Color.warmGreen))
+                .overlay(
+                    Image(systemName: source?.icon ?? "arrow.up")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundStyle(Color.warmGreen)
+                )
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(income.incomeDescription)
                     .font(.system(size: 14, weight: .semibold))
                     .foregroundStyle(Color.warmInk)
-                Text(shortDate(income.date))
+                Text(source.map { "\($0.label) · \(shortDate(income.date))" } ?? shortDate(income.date))
                     .font(.system(size: 12))
                     .foregroundStyle(Color.warmInkMuted)
             }

--- a/Savely/Views/MainNavigationView.swift
+++ b/Savely/Views/MainNavigationView.swift
@@ -316,13 +316,10 @@ func formatKeypadAmount(_ raw: String) -> String {
 
 // MARK: - Quick expense
 
-private let expenseCats: [(label: String, bg: Color, fg: Color)] = [
-    ("Coffee",   .warmAmberSoft, .warmAmber),
-    ("Food",     .warmGreenSoft, .warmGreen),
-    ("Transit",  .warmSkySoft,   .warmSky),
-    ("Shopping", .warmClaySoft,  .warmClay),
-    ("Other",    .warmBg,        .warmInkSoft),
-]
+/// The expense chips, straight from the canonical categories (what gets stored).
+private let expenseCats: [(label: String, bg: Color, fg: Color)] = ExpenseCategory.allCases.map {
+    ($0.label, $0.tileBackground, $0 == .other ? Color.warmInkSoft : $0.tileColor)
+}
 
 struct WarmQuickExpenseView: View {
     @Environment(\.modelContext) private var modelContext
@@ -330,7 +327,7 @@ struct WarmQuickExpenseView: View {
 
     @State private var amountStr = "0"
     @State private var description = ""
-    @State private var selectedCat = "Coffee"
+    @State private var selectedCat = ExpenseCategory.coffee.label
     @StateObject private var vm = ExpenseTrackerViewModel()
 
     private var canSave: Bool { amountStr != "0" }
@@ -404,8 +401,10 @@ struct WarmQuickExpenseView: View {
 
     private func saveAndDismiss() {
         guard canSave, let amt = Double(amountStr), amt > 0 else { return }
+        // Description and category are independent: the chip is stored as
+        // the category always, and only stands in for an empty description.
         vm.expenseDescription = description.isEmpty ? selectedCat : description
-        vm.amount = amountStr; vm.addExpense(); onSave()
+        vm.amount = amountStr; vm.addExpense(category: selectedCat); onSave()
     }
 }
 
@@ -420,11 +419,11 @@ struct WarmQuickIncomeView: View {
 
     @State private var amountStr = "0"
     @State private var description = ""
-    @State private var selectedSource = "Paycheck"
+    @State private var selectedSource = IncomeSource.paycheck.label
     @State private var autoMoveArmed = false
     @StateObject private var vm = IncomesTrackerViewModel()
 
-    private let sources = ["Paycheck", "Freelance", "Gift", "Other"]
+    private let sources = IncomeSource.allCases.map(\.label)
     private var canSave: Bool { amountStr != "0" }
     private var enteredAmount: Double { Double(amountStr) ?? 0 }
 
@@ -545,7 +544,7 @@ struct WarmQuickIncomeView: View {
 
     private func bannerText(for suggestion: AutoMoveSuggestion) -> AttributedString {
         let amount = "$\(Int(suggestion.amount))"
-        let origin = selectedSource == "Paycheck" ? "paycheck" : "income"
+        let origin = selectedSource == IncomeSource.paycheck.label ? "paycheck" : "income"
         let raw = autoMoveArmed
             ? "**Moving \(amount)** to \(suggestion.goal.name) when you save."
             : "**Auto-move \(amount)** to \(suggestion.goal.name) from this \(origin)?"
@@ -559,7 +558,7 @@ struct WarmQuickIncomeView: View {
         let armedSuggestion = autoMoveArmed ? autoMoveSuggestion : nil
         vm.incomeDescription = description.isEmpty ? selectedSource : description
         vm.amount = amountStr
-        vm.addIncome()
+        vm.addIncome(source: selectedSource)
         if let suggestion = armedSuggestion {
             suggestion.apply()
             try? modelContext.save()

--- a/Savely/Views/ProfileTab/ProfileView.swift
+++ b/Savely/Views/ProfileTab/ProfileView.swift
@@ -10,6 +10,7 @@ struct ProfileView: View {
     @Query private var expenses: [ExpenseModel]
     @Query private var goals: [GoalModel]
     @State private var showingAchievements = false
+    @State private var showingReports = false
     @State private var showingTipHistory = false
     @State private var showingDeleteDialog = false
     @State private var showingDeleteFinalConfirm = false
@@ -77,6 +78,7 @@ struct ProfileView: View {
             Text(Strings.Profile.deleteAllDataConfirmMessage)
         }
         .navigationDestination(isPresented: $showingAchievements) { AchievementsView() }
+        .navigationDestination(isPresented: $showingReports) { ReportsView() }
         .navigationDestination(isPresented: $showingTipHistory) { TipHistoryView() }
         .onAppear { viewModel.setModelContext(modelContext) }
         .task { await viewModel.refreshReminderState() }
@@ -251,6 +253,8 @@ struct ProfileView: View {
             .padding(.horizontal, 16).padding(.vertical, 14)
             WarmDivider()
             SettingsNavRow(icon: "doc.text.fill", title: "Weekly PDF report", onTap: { viewModel.generateWeeklyReportPDF() })
+            WarmDivider()
+            SettingsNavRow(icon: "chart.bar", title: "Reports", onTap: { showingReports = true })
             WarmDivider()
             SettingsNavRow(icon: "trash", title: Strings.Profile.deleteAllDataLabel, color: Color.warmClay, onTap: { showingDeleteDialog = true })
         }

--- a/SavelyTests/CategoryPersistenceTests.swift
+++ b/SavelyTests/CategoryPersistenceTests.swift
@@ -1,0 +1,89 @@
+//
+//  CategoryPersistenceTests.swift
+//  SavelyTests
+//
+
+import XCTest
+import SwiftData
+@testable import Savely
+
+@MainActor
+final class CategoryPersistenceTests: XCTestCase {
+    private var container: ModelContainer!
+    private var context: ModelContext!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        container = try ModelContainer(for: ExpenseModel.self, IncomeModel.self, configurations: config)
+        context = ModelContext(container)
+    }
+
+    override func tearDownWithError() throws {
+        context = nil
+        container = nil
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Round trips
+
+    func testExpenseRoundTripsItsCategory() throws {
+        context.insert(ExpenseModel(expenseDescription: "Zara", amount: 42, date: Date(), category: "Shopping"))
+        try context.save()
+
+        let fetched = try XCTUnwrap(try context.fetch(FetchDescriptor<ExpenseModel>()).first)
+        XCTAssertEqual(fetched.category, "Shopping")
+    }
+
+    func testIncomeRoundTripsItsSource() throws {
+        context.insert(IncomeModel(incomeDescription: "August", amount: 500, date: Date(), source: "Paycheck"))
+        try context.save()
+
+        let fetched = try XCTUnwrap(try context.fetch(FetchDescriptor<IncomeModel>()).first)
+        XCTAssertEqual(fetched.source, "Paycheck")
+    }
+
+    func testCategoryAndSourceDefaultToNil() throws {
+        // The shape every pre-existing row has after the additive migration.
+        context.insert(ExpenseModel(expenseDescription: "Coffee", amount: 3, date: Date()))
+        context.insert(IncomeModel(incomeDescription: "Gift", amount: 20, date: Date()))
+        try context.save()
+
+        XCTAssertNil(try XCTUnwrap(try context.fetch(FetchDescriptor<ExpenseModel>()).first).category)
+        XCTAssertNil(try XCTUnwrap(try context.fetch(FetchDescriptor<IncomeModel>()).first).source)
+    }
+
+    // MARK: - Display fallback
+
+    func testStoredCategoryWinsOverContradictingKeywords() {
+        // Description screams "coffee"; the user said Shopping. The user wins.
+        XCTAssertEqual(ExpenseCategory.display(stored: "Shopping", description: "coffee mug gift"), .shopping)
+    }
+
+    func testNilCategoryFallsBackToInference() {
+        XCTAssertEqual(ExpenseCategory.display(stored: nil, description: "Uber to work"), .transit)
+        XCTAssertEqual(ExpenseCategory.display(stored: nil, description: "Whole Foods run"), .food)
+        XCTAssertEqual(ExpenseCategory.display(stored: nil, description: "Morning cafe"), .coffee)
+    }
+
+    func testUnknownTextInfersOther() {
+        XCTAssertEqual(ExpenseCategory.display(stored: nil, description: "Something unrelated"), .other)
+    }
+
+    func testUnknownStoredValueFallsBackToInference() {
+        // A value that is not one of the five chips is treated like nil.
+        XCTAssertEqual(ExpenseCategory.display(stored: "Groceries", description: "Whole Foods"), .food)
+    }
+
+    func testIncomeSourceShowsNothingWhenNotStored() {
+        XCTAssertNil(IncomeSource.display(stored: nil))
+        XCTAssertEqual(IncomeSource.display(stored: "Freelance"), .freelance)
+    }
+
+    // MARK: - The chip strings are the stored strings
+
+    func testChipLabelsAreStableStorageKeys() {
+        XCTAssertEqual(ExpenseCategory.allCases.map(\.rawValue), ["Coffee", "Food", "Transit", "Shopping", "Other"])
+        XCTAssertEqual(IncomeSource.allCases.map(\.rawValue), ["Paycheck", "Freelance", "Gift", "Other"])
+    }
+}


### PR DESCRIPTION
## Summary
Executes `docs/plans/pr-b-real-categories.md`.

- **Model:** `ExpenseModel.category: String?` and `IncomeModel.source: String?`, nil by default — additive, SwiftData migrates in place. The stored value is the chip label as-is.
- **One source of truth:** `Savely/Utilities/MoneyCategories.swift` — `ExpenseCategory` (Coffee / Food / Transit / Shopping / Other) and `IncomeSource` (Paycheck / Freelance / Gift / Other) enums own the chips, their storage keys, and the icon/tile pairing from the plan's table. `ExpenseCategory.display(stored:description:)` prefers the stored chip and falls back to the old keyword inference, which is kept **only** for legacy rows and is never written back to the store.
- **Write paths:** both quick-add sheets store the chip always (`addExpense(category:)` / `addIncome(source:)`); the chip still stands in for an empty description, but description and category are now independent. Inline Money-tab forms pass nothing; the receipt scanner leaves `category` nil (plan decision).
- **Display:** expense rows show the stored category — Food / Shopping / Other finally have their own icon and tile; income rows show a source icon and "Source · date" when stored, unchanged when not.
- **ReportsView resurrected:** reachable from Profile → Reports; the `Environment(\.modelContext).wrappedValue`-in-`init` anti-pattern is gone; income by source and expenses by category, refetch on date change, Warm Meadow layout.
- **Tests:** `CategoryPersistenceTests` (in-memory `ModelContainer`) — round trips, nil defaults, stored chip beats contradicting keywords, unknown stored value behaves like nil, chip strings pinned as storage keys.

## One deliberate deviation from the plan
The plan keeps ReportsView's `SectorMark` pie, grouped by category. `PRODUCT.md` (merged after the plan, #36) lists pie charts as an anti-reference. I used **horizontal `BarMark`s** by category/source instead — same data, no pie.

## Test plan
- [x] `xcodebuild build` — BUILD SUCCEEDED
- [x] `xcodebuild test -skip-testing:SavelyUITests` — TEST SUCCEEDED (9 new `CategoryPersistenceTests`)
- [x] `swiftlint lint --strict` — 0
- [x] **In-place upgrade verified, no store reset:** built `dev` in a worktree, installed it, seeded 2 expenses + 1 income into the **old-schema** SQLite store, installed this branch's build over it, launched, and read the store back — `ZCATEGORY` / `ZSOURCE` columns added, all 3 rows intact with `NULL` (see the sqlite dump below).
- [ ] **Simulator UI walk NOT done by me** (Claude Code simulator panel is down for this session; no taps). Please check: quick-add "Zara" + Shopping → Money row shows the bag tile + "Shopping" (not a keyword guess); income with Freelance → row shows the laptop tile + "Freelance · date"; legacy rows unchanged; Profile → Reports opens with bars named by chip.
- [x] Test data uninstalled

```
=== NEW schema ZEXPENSEMODEL ===
Z_PK Z_ENT Z_OPT ZAMOUNT ZDATE ZEXPENSEDESCRIPTION ZID ZCATEGORY
Z_PK|ZEXPENSEDESCRIPTION|ZAMOUNT|ZCATEGORY
1|Uber to work|42.0|
2|Morning cafe|3.5|
Z_PK|ZINCOMEDESCRIPTION|ZAMOUNT|ZSOURCE
1|Legacy paycheck|500.0|
```

## Risks
- Schema change (additive optional). Verified as above; SwiftData lightweight migration handles it.
- The `legacyInferred` mapping folds "grocery/restaurant" into **Food** (there is no "Groceries" chip); legacy rows that used to read "Groceries" now read "Food" with the fork-and-knife tile.
- `expenseCats` in the quick-add sheet is now derived from the enum; "Other" keeps its softer `warmInkSoft` label color as before.

## Checklist
- [x] `feat/` branch, Conventional Commits, no AI attribution
- [x] New user-facing strings are literals per the plan's string policy (String Catalog auto-extraction)
- [x] No secrets staged
- [x] Tests added