### PR TITLE
feat(goals): deposit ledger, edit sheet, real pace, wizard fixes

### DIFF
--- a/Savely.xcodeproj/project.pbxproj
+++ b/Savely.xcodeproj/project.pbxproj
@@ -12,8 +12,11 @@
 		A11A0002C0DE5AFE10000002 /* AmountParsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A0001C0DE5AFE10000001 /* AmountParsing.swift */; };
 		A11A0006C0DE5AFE10000006 /* ReminderSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A0005C0DE5AFE10000005 /* ReminderSettings.swift */; };
 		A11A000CC0DE5AFE1000000C /* MoneyCategories.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A000BC0DE5AFE1000000B /* MoneyCategories.swift */; };
+		A11A0010C0DE5AFE10000010 /* DepositModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A000FC0DE5AFE1000000F /* DepositModel.swift */; };
+		A11A0012C0DE5AFE10000012 /* GoalDeposits.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A0011C0DE5AFE10000011 /* GoalDeposits.swift */; };
 		A11A0008C0DE5AFE10000008 /* ReminderSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A0007C0DE5AFE10000007 /* ReminderSettingsTests.swift */; };
 		A11A000EC0DE5AFE1000000E /* CategoryPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A000DC0DE5AFE1000000D /* CategoryPersistenceTests.swift */; };
+		A11A0014C0DE5AFE10000014 /* GoalDepositsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A0013C0DE5AFE10000013 /* GoalDepositsTests.swift */; };
 		A11A0004C0DE5AFE10000004 /* AmountParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A0003C0DE5AFE10000003 /* AmountParsingTests.swift */; };
 		510740529955B0B1E6EA730D /* AchievementEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62FA742D1E24F010F3273E30 /* AchievementEngineTests.swift */; };
 		F764EBD092BA4435466DD9AA /* AchievementEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12789AD27FF1A7114156F945 /* AchievementEngine.swift */; };
@@ -103,8 +106,11 @@
 		A11A0001C0DE5AFE10000001 /* AmountParsing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmountParsing.swift; sourceTree = "<group>"; };
 		A11A0005C0DE5AFE10000005 /* ReminderSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderSettings.swift; sourceTree = "<group>"; };
 		A11A000BC0DE5AFE1000000B /* MoneyCategories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoneyCategories.swift; sourceTree = "<group>"; };
+		A11A000FC0DE5AFE1000000F /* DepositModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DepositModel.swift; sourceTree = "<group>"; };
+		A11A0011C0DE5AFE10000011 /* GoalDeposits.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalDeposits.swift; sourceTree = "<group>"; };
 		A11A0007C0DE5AFE10000007 /* ReminderSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderSettingsTests.swift; sourceTree = "<group>"; };
 		A11A000DC0DE5AFE1000000D /* CategoryPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryPersistenceTests.swift; sourceTree = "<group>"; };
+		A11A0013C0DE5AFE10000013 /* GoalDepositsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalDepositsTests.swift; sourceTree = "<group>"; };
 		A11A0003C0DE5AFE10000003 /* AmountParsingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmountParsingTests.swift; sourceTree = "<group>"; };
 		62FA742D1E24F010F3273E30 /* AchievementEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchievementEngineTests.swift; sourceTree = "<group>"; };
 		12789AD27FF1A7114156F945 /* AchievementEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchievementEngine.swift; sourceTree = "<group>"; };
@@ -251,6 +257,7 @@
 				A11A0001C0DE5AFE10000001 /* AmountParsing.swift */,
 				A11A0005C0DE5AFE10000005 /* ReminderSettings.swift */,
 				A11A000BC0DE5AFE1000000B /* MoneyCategories.swift */,
+				A11A0011C0DE5AFE10000011 /* GoalDeposits.swift */,
 				12789AD27FF1A7114156F945 /* AchievementEngine.swift */,
 				693B815A380D566280140319 /* FeatureFlags.swift */,
 				1DE9FE162D066EE20069AA64 /* ReportsPDFGenerator.swift */,
@@ -449,6 +456,7 @@
 				A11A0003C0DE5AFE10000003 /* AmountParsingTests.swift */,
 				A11A0007C0DE5AFE10000007 /* ReminderSettingsTests.swift */,
 				A11A000DC0DE5AFE1000000D /* CategoryPersistenceTests.swift */,
+				A11A0013C0DE5AFE10000013 /* GoalDepositsTests.swift */,
 				62FA742D1E24F010F3273E30 /* AchievementEngineTests.swift */,
 				1DC258182CC07DCF0002DDE3 /* SavelyTests.swift */,
 			);
@@ -498,6 +506,7 @@
 			isa = PBXGroup;
 			children = (
 				1DC258482CC629210002DDE3 /* GoalModel.swift */,
+				A11A000FC0DE5AFE1000000F /* DepositModel.swift */,
 				1DC2584A2CC629540002DDE3 /* ExpenseModel.swift */,
 				1DC2584E2CC62A160002DDE3 /* TipModel.swift */,
 				1DC014102CE5AFAD009A46E1 /* OnboardingStepModel.swift */,
@@ -676,6 +685,8 @@
 				A11A0002C0DE5AFE10000002 /* AmountParsing.swift in Sources */,
 				A11A0006C0DE5AFE10000006 /* ReminderSettings.swift in Sources */,
 				A11A000CC0DE5AFE1000000C /* MoneyCategories.swift in Sources */,
+				A11A0010C0DE5AFE10000010 /* DepositModel.swift in Sources */,
+				A11A0012C0DE5AFE10000012 /* GoalDeposits.swift in Sources */,
 				F764EBD092BA4435466DD9AA /* AchievementEngine.swift in Sources */,
 				ED04D2F84390584EB7EC0615 /* WelcomeStepView.swift in Sources */,
 				699FCB7F699B1E9C9C644AF3 /* SproutMark.swift in Sources */,
@@ -731,6 +742,7 @@
 				A11A0004C0DE5AFE10000004 /* AmountParsingTests.swift in Sources */,
 				A11A0008C0DE5AFE10000008 /* ReminderSettingsTests.swift in Sources */,
 				A11A000EC0DE5AFE1000000E /* CategoryPersistenceTests.swift in Sources */,
+				A11A0014C0DE5AFE10000014 /* GoalDepositsTests.swift in Sources */,
 				510740529955B0B1E6EA730D /* AchievementEngineTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Savely.xcodeproj/project.pbxproj
+++ b/Savely.xcodeproj/project.pbxproj
@@ -16,10 +16,12 @@
 		A11A0012C0DE5AFE10000012 /* GoalDeposits.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A0011C0DE5AFE10000011 /* GoalDeposits.swift */; };
 		A11A0016C0DE5AFE10000016 /* GoalEditSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A0015C0DE5AFE10000015 /* GoalEditSheet.swift */; };
 		A11A0018C0DE5AFE10000018 /* GoalEditValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A0017C0DE5AFE10000017 /* GoalEditValidation.swift */; };
+		A11A001CC0DE5AFE1000001C /* GoalPace.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A001BC0DE5AFE1000001B /* GoalPace.swift */; };
 		A11A0008C0DE5AFE10000008 /* ReminderSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A0007C0DE5AFE10000007 /* ReminderSettingsTests.swift */; };
 		A11A000EC0DE5AFE1000000E /* CategoryPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A000DC0DE5AFE1000000D /* CategoryPersistenceTests.swift */; };
 		A11A0014C0DE5AFE10000014 /* GoalDepositsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A0013C0DE5AFE10000013 /* GoalDepositsTests.swift */; };
 		A11A001AC0DE5AFE1000001A /* GoalEditValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A0019C0DE5AFE10000019 /* GoalEditValidationTests.swift */; };
+		A11A001EC0DE5AFE1000001E /* GoalPaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A001DC0DE5AFE1000001D /* GoalPaceTests.swift */; };
 		A11A0004C0DE5AFE10000004 /* AmountParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A0003C0DE5AFE10000003 /* AmountParsingTests.swift */; };
 		510740529955B0B1E6EA730D /* AchievementEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62FA742D1E24F010F3273E30 /* AchievementEngineTests.swift */; };
 		F764EBD092BA4435466DD9AA /* AchievementEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12789AD27FF1A7114156F945 /* AchievementEngine.swift */; };
@@ -113,10 +115,12 @@
 		A11A0011C0DE5AFE10000011 /* GoalDeposits.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalDeposits.swift; sourceTree = "<group>"; };
 		A11A0015C0DE5AFE10000015 /* GoalEditSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalEditSheet.swift; sourceTree = "<group>"; };
 		A11A0017C0DE5AFE10000017 /* GoalEditValidation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalEditValidation.swift; sourceTree = "<group>"; };
+		A11A001BC0DE5AFE1000001B /* GoalPace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalPace.swift; sourceTree = "<group>"; };
 		A11A0007C0DE5AFE10000007 /* ReminderSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderSettingsTests.swift; sourceTree = "<group>"; };
 		A11A000DC0DE5AFE1000000D /* CategoryPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryPersistenceTests.swift; sourceTree = "<group>"; };
 		A11A0013C0DE5AFE10000013 /* GoalDepositsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalDepositsTests.swift; sourceTree = "<group>"; };
 		A11A0019C0DE5AFE10000019 /* GoalEditValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalEditValidationTests.swift; sourceTree = "<group>"; };
+		A11A001DC0DE5AFE1000001D /* GoalPaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalPaceTests.swift; sourceTree = "<group>"; };
 		A11A0003C0DE5AFE10000003 /* AmountParsingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmountParsingTests.swift; sourceTree = "<group>"; };
 		62FA742D1E24F010F3273E30 /* AchievementEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchievementEngineTests.swift; sourceTree = "<group>"; };
 		12789AD27FF1A7114156F945 /* AchievementEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchievementEngine.swift; sourceTree = "<group>"; };
@@ -265,6 +269,7 @@
 				A11A000BC0DE5AFE1000000B /* MoneyCategories.swift */,
 				A11A0011C0DE5AFE10000011 /* GoalDeposits.swift */,
 				A11A0017C0DE5AFE10000017 /* GoalEditValidation.swift */,
+				A11A001BC0DE5AFE1000001B /* GoalPace.swift */,
 				12789AD27FF1A7114156F945 /* AchievementEngine.swift */,
 				693B815A380D566280140319 /* FeatureFlags.swift */,
 				1DE9FE162D066EE20069AA64 /* ReportsPDFGenerator.swift */,
@@ -466,6 +471,7 @@
 				A11A000DC0DE5AFE1000000D /* CategoryPersistenceTests.swift */,
 				A11A0013C0DE5AFE10000013 /* GoalDepositsTests.swift */,
 				A11A0019C0DE5AFE10000019 /* GoalEditValidationTests.swift */,
+				A11A001DC0DE5AFE1000001D /* GoalPaceTests.swift */,
 				62FA742D1E24F010F3273E30 /* AchievementEngineTests.swift */,
 				1DC258182CC07DCF0002DDE3 /* SavelyTests.swift */,
 			);
@@ -698,6 +704,7 @@
 				A11A0012C0DE5AFE10000012 /* GoalDeposits.swift in Sources */,
 				A11A0016C0DE5AFE10000016 /* GoalEditSheet.swift in Sources */,
 				A11A0018C0DE5AFE10000018 /* GoalEditValidation.swift in Sources */,
+				A11A001CC0DE5AFE1000001C /* GoalPace.swift in Sources */,
 				F764EBD092BA4435466DD9AA /* AchievementEngine.swift in Sources */,
 				ED04D2F84390584EB7EC0615 /* WelcomeStepView.swift in Sources */,
 				699FCB7F699B1E9C9C644AF3 /* SproutMark.swift in Sources */,
@@ -755,6 +762,7 @@
 				A11A000EC0DE5AFE1000000E /* CategoryPersistenceTests.swift in Sources */,
 				A11A0014C0DE5AFE10000014 /* GoalDepositsTests.swift in Sources */,
 				A11A001AC0DE5AFE1000001A /* GoalEditValidationTests.swift in Sources */,
+				A11A001EC0DE5AFE1000001E /* GoalPaceTests.swift in Sources */,
 				510740529955B0B1E6EA730D /* AchievementEngineTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Savely.xcodeproj/project.pbxproj
+++ b/Savely.xcodeproj/project.pbxproj
@@ -14,9 +14,12 @@
 		A11A000CC0DE5AFE1000000C /* MoneyCategories.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A000BC0DE5AFE1000000B /* MoneyCategories.swift */; };
 		A11A0010C0DE5AFE10000010 /* DepositModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A000FC0DE5AFE1000000F /* DepositModel.swift */; };
 		A11A0012C0DE5AFE10000012 /* GoalDeposits.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A0011C0DE5AFE10000011 /* GoalDeposits.swift */; };
+		A11A0016C0DE5AFE10000016 /* GoalEditSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A0015C0DE5AFE10000015 /* GoalEditSheet.swift */; };
+		A11A0018C0DE5AFE10000018 /* GoalEditValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A0017C0DE5AFE10000017 /* GoalEditValidation.swift */; };
 		A11A0008C0DE5AFE10000008 /* ReminderSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A0007C0DE5AFE10000007 /* ReminderSettingsTests.swift */; };
 		A11A000EC0DE5AFE1000000E /* CategoryPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A000DC0DE5AFE1000000D /* CategoryPersistenceTests.swift */; };
 		A11A0014C0DE5AFE10000014 /* GoalDepositsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A0013C0DE5AFE10000013 /* GoalDepositsTests.swift */; };
+		A11A001AC0DE5AFE1000001A /* GoalEditValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A0019C0DE5AFE10000019 /* GoalEditValidationTests.swift */; };
 		A11A0004C0DE5AFE10000004 /* AmountParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A0003C0DE5AFE10000003 /* AmountParsingTests.swift */; };
 		510740529955B0B1E6EA730D /* AchievementEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62FA742D1E24F010F3273E30 /* AchievementEngineTests.swift */; };
 		F764EBD092BA4435466DD9AA /* AchievementEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12789AD27FF1A7114156F945 /* AchievementEngine.swift */; };
@@ -108,9 +111,12 @@
 		A11A000BC0DE5AFE1000000B /* MoneyCategories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoneyCategories.swift; sourceTree = "<group>"; };
 		A11A000FC0DE5AFE1000000F /* DepositModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DepositModel.swift; sourceTree = "<group>"; };
 		A11A0011C0DE5AFE10000011 /* GoalDeposits.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalDeposits.swift; sourceTree = "<group>"; };
+		A11A0015C0DE5AFE10000015 /* GoalEditSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalEditSheet.swift; sourceTree = "<group>"; };
+		A11A0017C0DE5AFE10000017 /* GoalEditValidation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalEditValidation.swift; sourceTree = "<group>"; };
 		A11A0007C0DE5AFE10000007 /* ReminderSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderSettingsTests.swift; sourceTree = "<group>"; };
 		A11A000DC0DE5AFE1000000D /* CategoryPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryPersistenceTests.swift; sourceTree = "<group>"; };
 		A11A0013C0DE5AFE10000013 /* GoalDepositsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalDepositsTests.swift; sourceTree = "<group>"; };
+		A11A0019C0DE5AFE10000019 /* GoalEditValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalEditValidationTests.swift; sourceTree = "<group>"; };
 		A11A0003C0DE5AFE10000003 /* AmountParsingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmountParsingTests.swift; sourceTree = "<group>"; };
 		62FA742D1E24F010F3273E30 /* AchievementEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchievementEngineTests.swift; sourceTree = "<group>"; };
 		12789AD27FF1A7114156F945 /* AchievementEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchievementEngine.swift; sourceTree = "<group>"; };
@@ -258,6 +264,7 @@
 				A11A0005C0DE5AFE10000005 /* ReminderSettings.swift */,
 				A11A000BC0DE5AFE1000000B /* MoneyCategories.swift */,
 				A11A0011C0DE5AFE10000011 /* GoalDeposits.swift */,
+				A11A0017C0DE5AFE10000017 /* GoalEditValidation.swift */,
 				12789AD27FF1A7114156F945 /* AchievementEngine.swift */,
 				693B815A380D566280140319 /* FeatureFlags.swift */,
 				1DE9FE162D066EE20069AA64 /* ReportsPDFGenerator.swift */,
@@ -356,6 +363,7 @@
 			isa = PBXGroup;
 			children = (
 				1DC258332CC07E460002DDE3 /* GoalsView.swift */,
+				A11A0015C0DE5AFE10000015 /* GoalEditSheet.swift */,
 				1DF7228F2F9C18FE00320B38 /* GoalDetailView.swift */,
 				1DF722952F9C2FA400320B38 /* AddGoalFlow.swift */,
 			);
@@ -457,6 +465,7 @@
 				A11A0007C0DE5AFE10000007 /* ReminderSettingsTests.swift */,
 				A11A000DC0DE5AFE1000000D /* CategoryPersistenceTests.swift */,
 				A11A0013C0DE5AFE10000013 /* GoalDepositsTests.swift */,
+				A11A0019C0DE5AFE10000019 /* GoalEditValidationTests.swift */,
 				62FA742D1E24F010F3273E30 /* AchievementEngineTests.swift */,
 				1DC258182CC07DCF0002DDE3 /* SavelyTests.swift */,
 			);
@@ -687,6 +696,8 @@
 				A11A000CC0DE5AFE1000000C /* MoneyCategories.swift in Sources */,
 				A11A0010C0DE5AFE10000010 /* DepositModel.swift in Sources */,
 				A11A0012C0DE5AFE10000012 /* GoalDeposits.swift in Sources */,
+				A11A0016C0DE5AFE10000016 /* GoalEditSheet.swift in Sources */,
+				A11A0018C0DE5AFE10000018 /* GoalEditValidation.swift in Sources */,
 				F764EBD092BA4435466DD9AA /* AchievementEngine.swift in Sources */,
 				ED04D2F84390584EB7EC0615 /* WelcomeStepView.swift in Sources */,
 				699FCB7F699B1E9C9C644AF3 /* SproutMark.swift in Sources */,
@@ -743,6 +754,7 @@
 				A11A0008C0DE5AFE10000008 /* ReminderSettingsTests.swift in Sources */,
 				A11A000EC0DE5AFE1000000E /* CategoryPersistenceTests.swift in Sources */,
 				A11A0014C0DE5AFE10000014 /* GoalDepositsTests.swift in Sources */,
+				A11A001AC0DE5AFE1000001A /* GoalEditValidationTests.swift in Sources */,
 				510740529955B0B1E6EA730D /* AchievementEngineTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Savely/Models/DepositModel.swift
+++ b/Savely/Models/DepositModel.swift
@@ -1,0 +1,39 @@
+//
+//  DepositModel.swift
+//  Savely
+//
+//  One row per movement of money into a goal — manual or payday auto-move.
+//  `GoalModel.current` stays the running total the UI reads; this is the
+//  record of how it got there. Written only through `GoalDeposits.record`.
+//
+
+import Foundation
+import SwiftData
+
+@Model
+class DepositModel {
+    @Attribute(.unique) var id: UUID
+    /// The goal this deposit went into. A plain UUID rather than a
+    /// relationship on purpose: deleting a goal should not cascade-delete
+    /// the history, and the ledger must not keep a deleted goal alive.
+    var goalID: UUID
+    var amount: Double
+    var date: Date
+    var note: String?
+    /// `DepositSource.rawValue` — "manual" or "auto-move".
+    var source: String
+
+    init(goalID: UUID, amount: Double, date: Date = Date(), note: String? = nil, source: DepositSource) {
+        self.id = UUID()
+        self.goalID = goalID
+        self.amount = amount
+        self.date = date
+        self.note = note
+        self.source = source.rawValue
+    }
+}
+
+enum DepositSource: String {
+    case manual = "manual"
+    case autoMove = "auto-move"
+}

--- a/Savely/Resources/Localizable.xcstrings
+++ b/Savely/Resources/Localizable.xcstrings
@@ -276,6 +276,9 @@
         }
       }
     },
+    "Amount" : {
+
+    },
     "amount_placeholder_label" : {
       "comment" : "Amount Placeholder Label",
       "extractionState" : "extracted_with_value",
@@ -368,6 +371,9 @@
           }
         }
       }
+    },
+    "Category" : {
+
     },
     "category_placeholder" : {
       "comment" : "Category Placeholder",
@@ -938,9 +944,6 @@
           }
         }
       }
-    },
-    "Expense" : {
-
     },
     "expense_distribution_label" : {
       "comment" : "Expense Distribution Label",
@@ -2265,6 +2268,9 @@
         }
       }
     },
+    "Reports" : {
+
+    },
     "reports_tab_string" : {
       "comment" : "Reports Tab String",
       "extractionState" : "extracted_with_value",
@@ -2641,6 +2647,9 @@
       }
     },
     "Skip" : {
+
+    },
+    "Source" : {
 
     },
     "Source · Today" : {

--- a/Savely/SavelyApp.swift
+++ b/Savely/SavelyApp.swift
@@ -23,7 +23,7 @@ struct SavelyApp: App {
                     NotificationManager.shared.requestAuthorization()
                 }
         }
-        .modelContainer(for: [TipModel.self, IncomeModel.self, ExpenseModel.self, GoalModel.self])
+        .modelContainer(for: [TipModel.self, IncomeModel.self, ExpenseModel.self, GoalModel.self, DepositModel.self])
     }
 }
 

--- a/Savely/Utilities/AutoMoveSuggestion.swift
+++ b/Savely/Utilities/AutoMoveSuggestion.swift
@@ -24,13 +24,15 @@ import Foundation
 /// **How much** — never more than reality allows:
 /// `min(configured pace, remaining to target, the income being logged,
 /// the month's affordable margin)`. The margin is
-/// `month incomes + this income − month expenses`: if the month is under
-/// water even counting this paycheck, nothing is suggested — money the
-/// month already spent should not be "saved" into a goal.
+/// `month incomes + this income − month expenses − month deposits`: if the
+/// month is under water even counting this paycheck, nothing is suggested —
+/// money the month already spent, or already moved into goals, should not
+/// be "saved" into a goal again.
 ///
 /// **When it moves** — never before the income is saved. YES only arms the
-/// banner; the deposit applies with the save, using the same clamp as the
-/// manual "Deposit to a goal" flow.
+/// banner; the deposit is recorded with the save through
+/// `GoalDeposits.record(source: .autoMove)`, the same path every manual
+/// deposit takes.
 struct AutoMoveSuggestion {
     let goal: GoalModel
     let amount: Double
@@ -43,6 +45,7 @@ struct AutoMoveSuggestion {
         incomeAmount: Double,
         monthIncomeTotal: Double = 0,
         monthExpenseTotal: Double = 0,
+        monthDepositTotal: Double = 0,
         now: Date = Date(),
         calendar: Calendar = .current
     ) -> AutoMoveSuggestion? {
@@ -77,18 +80,12 @@ struct AutoMoveSuggestion {
         // Affordability: what this month can actually spare, counting the
         // income being logged. Callers that pass no month totals get the
         // plain income cap.
-        let monthMargin = monthIncomeTotal + incomeAmount - monthExpenseTotal
+        let monthMargin = monthIncomeTotal + incomeAmount - monthExpenseTotal - monthDepositTotal
         let remaining = pick.target - pick.current
         let raw = min(pick.autoMoveAmount, remaining, incomeAmount, max(0, monthMargin))
         let amount = (raw * 100).rounded() / 100
         guard amount >= minimumAmount else { return nil }
 
         return AutoMoveSuggestion(goal: pick, amount: amount)
-    }
-
-    /// Applies the armed suggestion — the exact clamp the manual
-    /// "Deposit to a goal" flow uses (`WarmQuickDepositView.saveDeposit`).
-    func apply() {
-        goal.current = min(goal.current + amount, goal.target)
     }
 }

--- a/Savely/Utilities/AutoMoveSuggestion.swift
+++ b/Savely/Utilities/AutoMoveSuggestion.swift
@@ -57,9 +57,9 @@ struct AutoMoveSuggestion {
         guard !eligible.isEmpty else { return nil }
 
         func requiredWeeklyPace(_ goal: GoalModel) -> Double? {
-            guard let deadline = goal.deadline, deadline > now else { return nil }
-            let weeks = max(1, calendar.dateComponents([.weekOfYear], from: now, to: deadline).weekOfYear ?? 1)
-            return (goal.target - goal.current) / Double(weeks)
+            GoalPace.requiredWeeklyPace(
+                remaining: goal.target - goal.current, deadline: goal.deadline, now: now, calendar: calendar
+            )
         }
 
         let pick = eligible.sorted { a, b in

--- a/Savely/Utilities/GoalDeposits.swift
+++ b/Savely/Utilities/GoalDeposits.swift
@@ -1,0 +1,68 @@
+//
+//  GoalDeposits.swift
+//  Savely
+//
+//  The one place money moves into a goal, and the one place pace math
+//  lives. Every deposit flow (goal detail, dashboard sheet, quick-deposit
+//  sheet, payday auto-move) goes through `record` so `GoalModel.current`
+//  and the `DepositModel` ledger can never disagree.
+//
+
+import Foundation
+import SwiftData
+
+enum GoalDepositsError: LocalizedError {
+    case nonPositiveAmount
+
+    var errorDescription: String? {
+        switch self {
+        case .nonPositiveAmount: return "Enter an amount greater than zero."
+        }
+    }
+}
+
+enum GoalDeposits {
+    /// Adds `amount` to the goal (clamped at its target, exactly as every
+    /// flow already did), inserts the ledger row, and saves.
+    ///
+    /// - Returns: the deposit that was recorded. Its `amount` is the amount
+    ///   *asked for*, not the clamped delta — the ledger records intent; the
+    ///   goal records the capped result.
+    @discardableResult
+    static func record(
+        goal: GoalModel,
+        amount: Double,
+        note: String? = nil,
+        source: DepositSource,
+        date: Date = Date(),
+        context: ModelContext
+    ) throws -> DepositModel {
+        guard amount > 0 else { throw GoalDepositsError.nonPositiveAmount }
+        goal.current = clampedCurrent(current: goal.current, adding: amount, target: goal.target)
+        let trimmedNote = note?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let deposit = DepositModel(
+            goalID: goal.id,
+            amount: amount,
+            date: date,
+            note: (trimmedNote?.isEmpty ?? true) ? nil : trimmedNote,
+            source: source
+        )
+        context.insert(deposit)
+        try context.save()
+        return deposit
+    }
+
+    /// The clamp every flow used inline: never past the target.
+    static func clampedCurrent(current: Double, adding amount: Double, target: Double) -> Double {
+        min(current + amount, target)
+    }
+
+    /// Sum of deposits into any goal during the calendar month of `now` —
+    /// the money the month has already set aside, which the payday
+    /// suggestion must not offer twice.
+    static func monthTotal(_ deposits: [DepositModel], now: Date = Date(), calendar: Calendar = .current) -> Double {
+        deposits
+            .filter { calendar.isDate($0.date, equalTo: now, toGranularity: .month) }
+            .reduce(0) { $0 + $1.amount }
+    }
+}

--- a/Savely/Utilities/GoalEditValidation.swift
+++ b/Savely/Utilities/GoalEditValidation.swift
@@ -1,0 +1,61 @@
+//
+//  GoalEditValidation.swift
+//  Savely
+//
+//  The rules the goal edit sheet enforces, as a pure function so they can
+//  be unit-tested without a view.
+//
+
+import Foundation
+
+enum GoalEditError: Equatable, LocalizedError {
+    case emptyName
+    case nonPositiveTarget
+    case targetBelowSaved(saved: Double)
+    case deadlineInPast
+    case nonPositiveAutoMove
+
+    var errorDescription: String? {
+        switch self {
+        case .emptyName:
+            return "Give the goal a name."
+        case .nonPositiveTarget:
+            return "The target has to be more than $0."
+        case .targetBelowSaved(let saved):
+            let f = NumberFormatter(); f.numberStyle = .currency; f.currencySymbol = "$"; f.maximumFractionDigits = 0
+            let savedText = f.string(from: NSNumber(value: saved)) ?? "$0"
+            return "You've already saved \(savedText) — the target can't be lower than that."
+        case .deadlineInPast:
+            return "Pick a date in the future, or turn the date off."
+        case .nonPositiveAutoMove:
+            return "Set an auto-move amount above $0, or turn auto-move off."
+        }
+    }
+}
+
+struct GoalEditDraft: Equatable {
+    var name: String
+    var target: Double
+    var hasDeadline: Bool
+    var deadline: Date
+    var autoMoveEnabled: Bool
+    var autoMoveAmount: Double
+
+    /// The name as it will be saved.
+    var trimmedName: String { name.trimmingCharacters(in: .whitespacesAndNewlines) }
+}
+
+enum GoalEditValidation {
+    /// First rule broken, or nil when the draft can be saved.
+    /// `current` is what the goal already holds — the target may not drop
+    /// below it (shrinking under saved money would show >100% and mean
+    /// nothing).
+    static func firstError(in draft: GoalEditDraft, current: Double, now: Date = Date()) -> GoalEditError? {
+        if draft.trimmedName.isEmpty { return .emptyName }
+        if draft.target <= 0 { return .nonPositiveTarget }
+        if draft.target < current { return .targetBelowSaved(saved: current) }
+        if draft.hasDeadline && draft.deadline <= now { return .deadlineInPast }
+        if draft.autoMoveEnabled && draft.autoMoveAmount <= 0 { return .nonPositiveAutoMove }
+        return nil
+    }
+}

--- a/Savely/Utilities/GoalPace.swift
+++ b/Savely/Utilities/GoalPace.swift
@@ -1,0 +1,127 @@
+//
+//  GoalPace.swift
+//  Savely
+//
+//  The pace policy, in one place: how fast a goal *needs* to grow to land
+//  on its date, how fast it *is* growing from its deposits, whether that is
+//  on track, and an ETA that is never faked. GoalDetailView, the Dashboard
+//  hero card, the Goals list and AutoMoveSuggestion all read from here.
+//
+
+import Foundation
+
+struct GoalPace: Equatable {
+    enum Status: Equatable {
+        case complete
+        case onTrack
+        case behind
+    }
+
+    /// Dollars per week needed to reach the target by the deadline.
+    /// nil when there is no deadline (or it has passed) or the goal is done.
+    let requiredWeekly: Double?
+    /// Dollars per week the goal is actually receiving (see `compute`).
+    let actualWeekly: Double
+    /// Weeks from `now` until the goal is funded at the actual pace.
+    /// nil when the pace is zero (no honest date exists) or the goal is done.
+    let etaWeeks: Double?
+    let status: Status
+
+    /// Deposits over this window feed `actualWeekly`.
+    static let actualWindowWeeks: Double = 4
+    /// Weeks per month, for turning a monthly auto-move into a weekly pace.
+    static let weeksPerMonth: Double = 4.33
+    /// ETAs past this are shown as "1+ year" rather than a fake date.
+    static let etaCapWeeks: Double = 52
+
+    // MARK: - Building blocks (also used by AutoMoveSuggestion)
+
+    /// Whole weeks from `now` to `deadline`, never below 1 so a deadline
+    /// this week still yields a finite pace.
+    static func weeksUntil(_ deadline: Date, from now: Date, calendar: Calendar = .current) -> Int {
+        max(1, calendar.dateComponents([.weekOfYear], from: now, to: deadline).weekOfYear ?? 1)
+    }
+
+    /// `remaining ÷ weeks to deadline`, or nil when there is no future deadline.
+    static func requiredWeeklyPace(remaining: Double, deadline: Date?, now: Date, calendar: Calendar = .current) -> Double? {
+        guard let deadline, deadline > now, remaining > 0 else { return nil }
+        return remaining / Double(weeksUntil(deadline, from: now, calendar: calendar))
+    }
+
+    // MARK: - Policy
+
+    /// - `actualWeekly`: average of the goal's deposits over the last four
+    ///   weeks. A goal with no deposits *ever* falls back to its configured
+    ///   auto-move amount as a weekly figure (`autoMoveAmount ÷ 4.33`) — the
+    ///   pace the user promised, until real deposits replace it.
+    /// - On track ⇔ complete, or no deadline, or `actualWeekly ≥ requiredWeekly`.
+    static func compute(
+        goal: GoalModel,
+        deposits: [DepositModel],
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> GoalPace {
+        let remaining = max(0, goal.target - goal.current)
+        if remaining <= 0 {
+            return GoalPace(requiredWeekly: nil, actualWeekly: 0, etaWeeks: nil, status: .complete)
+        }
+
+        let required = requiredWeeklyPace(remaining: remaining, deadline: goal.deadline, now: now, calendar: calendar)
+
+        let goalDeposits = deposits.filter { $0.goalID == goal.id }
+        let actual: Double
+        if goalDeposits.isEmpty {
+            actual = goal.autoMoveEnabled ? goal.autoMoveAmount / weeksPerMonth : 0
+        } else {
+            let windowStart = calendar.date(byAdding: .day, value: -Int(actualWindowWeeks * 7), to: now) ?? now
+            let recent = goalDeposits.filter { $0.date > windowStart && $0.date <= now }
+            actual = recent.reduce(0) { $0 + $1.amount } / actualWindowWeeks
+        }
+
+        let eta: Double? = actual > 0 ? remaining / actual : nil
+        let status: Status
+        if let required, actual < required {
+            status = .behind
+        } else {
+            status = .onTrack
+        }
+        return GoalPace(requiredWeekly: required, actualWeekly: actual, etaWeeks: eta, status: status)
+    }
+
+    // MARK: - Display
+
+    var label: String {
+        switch status {
+        case .complete: return "Complete!"
+        case .onTrack: return "On track"
+        case .behind: return "Behind"
+        }
+    }
+
+    /// "Jun 12", "1+ year", or "—". Never a made-up date.
+    func etaText(from now: Date = Date(), calendar: Calendar = .current) -> String {
+        guard status != .complete else { return "Done!" }
+        guard let etaWeeks else { return "—" }
+        if etaWeeks > Self.etaCapWeeks { return "1+ year" }
+        let date = calendar.date(byAdding: .day, value: Int((etaWeeks * 7).rounded()), to: now) ?? now
+        let f = DateFormatter(); f.dateFormat = "MMM d"
+        return f.string(from: date)
+    }
+}
+
+/// Remembers which completed goals were already celebrated (UserDefaults),
+/// so the completion pop runs exactly once per goal. Mirrors AchievementStore.
+enum GoalCelebrationStore {
+    private static let key = "celebratedGoalIds"
+
+    static func newlyCompleted(_ completed: [GoalModel]) -> Set<UUID> {
+        let celebrated = Set(UserDefaults.standard.stringArray(forKey: key) ?? [])
+        return Set(completed.map(\.id).filter { !celebrated.contains($0.uuidString) })
+    }
+
+    static func markCelebrated(_ completed: [GoalModel]) {
+        let celebrated = Set(UserDefaults.standard.stringArray(forKey: key) ?? [])
+        let ids = Set(completed.map(\.id.uuidString))
+        UserDefaults.standard.set(Array(celebrated.union(ids)).sorted(), forKey: key)
+    }
+}

--- a/Savely/ViewModels/GoalsTab/GoalsViewModel.swift
+++ b/Savely/ViewModels/GoalsTab/GoalsViewModel.swift
@@ -111,15 +111,16 @@ class GoalsViewModel: ObservableObject {
     }
 
 
+    /// Toggles the star: tapping the current favorite un-favorites it;
+    /// tapping another goal moves the star there. At most one favorite.
     func setFavorite(goal: GoalModel) {
         guard let modelContext = modelContext else { return }
 
-        // Desmarcar todas las metas excepto la seleccionada
+        let wasFavorite = goal.isFavorite
         for existingGoal in goals where existingGoal.isFavorite && existingGoal.id != goal.id {
             existingGoal.isFavorite = false
         }
-        // Marcar la meta seleccionada como favorita
-        goal.isFavorite = true
+        goal.isFavorite = !wasFavorite
 
         // Guardar el contexto después de modificar las metas
         do {

--- a/Savely/Views/DashboardTab/DashboardView.swift
+++ b/Savely/Views/DashboardTab/DashboardView.swift
@@ -290,6 +290,7 @@ struct DepositSheet: View {
     @Environment(\.dismiss) private var dismiss
     @State private var amountText = ""
     @State private var note = ""
+    @State private var errorMessage: String?
     private let quickAmounts: [Double] = [25, 50, 100, 250]
 
     var body: some View {
@@ -369,15 +370,23 @@ struct DepositSheet: View {
         .background(Color.warmSurface)
         .presentationDetents([.medium, .large])
         .presentationDragIndicator(.hidden)
+        .alert("Couldn't save the deposit", isPresented: Binding(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(errorMessage ?? "")
+        }
     }
 
     private var depositAmount: Double? { Double(amountText) }
 
     private func saveDeposit() {
         guard let amt = depositAmount, amt > 0 else { return }
-        goal.current = min(goal.current + amt, goal.target)
-        try? modelContext.save()
-        dismiss()
+        do {
+            try GoalDeposits.record(goal: goal, amount: amt, note: note, source: .manual, context: modelContext)
+            dismiss()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
     }
 }
 

--- a/Savely/Views/DashboardTab/DashboardView.swift
+++ b/Savely/Views/DashboardTab/DashboardView.swift
@@ -164,6 +164,16 @@ struct HeroGoalCard: View {
     let modelContext: ModelContext
     @State private var showDepositSheet = false
     @State private var showEditSheet = false
+    @Query private var goalDeposits: [DepositModel]
+
+    init(goal: GoalModel, modelContext: ModelContext) {
+        self.goal = goal
+        self.modelContext = modelContext
+        let goalID = goal.id
+        _goalDeposits = Query(filter: #Predicate<DepositModel> { $0.goalID == goalID })
+    }
+
+    private var pace: GoalPace { GoalPace.compute(goal: goal, deposits: goalDeposits) }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -227,9 +237,9 @@ struct HeroGoalCard: View {
                                 .font(.system(size: 11, weight: .semibold))
                                 .foregroundStyle(Color.warmInkMuted)
                                 .tracking(0.8)
-                            Text(paceText)
+                            Text(pace.label)
                                 .font(.system(size: 14, weight: .semibold))
-                                .foregroundStyle(Color.warmGreen)
+                                .foregroundStyle(pace.status == .behind ? Color.warmClay : Color.warmGreen)
                         }
                     }
                 }
@@ -272,10 +282,6 @@ struct HeroGoalCard: View {
         .sheet(isPresented: $showEditSheet) {
             GoalEditSheet(goal: goal)
         }
-    }
-
-    private var paceText: String {
-        goal.progress >= 1.0 ? "Complete!" : "On track"
     }
 
     private func formattedAmount(_ v: Double) -> String {

--- a/Savely/Views/DashboardTab/DashboardView.swift
+++ b/Savely/Views/DashboardTab/DashboardView.swift
@@ -163,6 +163,7 @@ struct HeroGoalCard: View {
     let goal: GoalModel
     let modelContext: ModelContext
     @State private var showDepositSheet = false
+    @State private var showEditSheet = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -249,13 +250,14 @@ struct HeroGoalCard: View {
                         .cornerRadius(14)
                     }
 
-                    Button(action: {}) {
+                    Button(action: { showEditSheet = true }) {
                         Image(systemName: "pencil")
                             .font(.system(size: 16))
                             .foregroundStyle(Color.warmInk)
                             .frame(width: 48, height: 48)
                             .overlay(RoundedRectangle(cornerRadius: 14).stroke(Color.warmLine, lineWidth: 1))
                     }
+                    .accessibilityLabel("Edit goal")
                 }
             }
             .padding(24)
@@ -266,6 +268,9 @@ struct HeroGoalCard: View {
         .shadow(color: Color.warmShadow, radius: 12, x: 0, y: 4)
         .sheet(isPresented: $showDepositSheet) {
             DepositSheet(goal: goal, modelContext: modelContext)
+        }
+        .sheet(isPresented: $showEditSheet) {
+            GoalEditSheet(goal: goal)
         }
     }
 

--- a/Savely/Views/GoalsTab/AddGoalFlow.swift
+++ b/Savely/Views/GoalsTab/AddGoalFlow.swift
@@ -5,26 +5,28 @@ import SwiftData
 
 final class AddGoalState: ObservableObject {
     @Published var name: String = ""
-    @Published var emoji: String = "✈️"
     @Published var color: GoalColor = .green
     @Published var amountStr: String = "0"
+    /// The calendar always holds a date so MiniCalendarView's binding stays
+    /// non-optional; `hasDeadline` says whether it counts. "No date" flips it
+    /// off; picking any day or duration flips it back on.
     @Published var deadline: Date = Calendar.current.date(byAdding: .month, value: 18, to: Date()) ?? Date()
+    @Published var hasDeadline: Bool = true
     @Published var autoDeposit: Bool = true
-    @Published var showReminders: Bool = true
     @Published var isFavorite: Bool = false
 
     var amount: Double { Double(amountStr) ?? 0 }
 
+    /// Required pace to the chosen date; 0 without a date (pace is undefined
+    /// then — the user sets an auto-move amount later in the edit sheet).
     var weeklyPace: Double {
-        let weeks = max(1, Calendar.current.dateComponents([.weekOfYear], from: Date(), to: deadline).weekOfYear ?? 78)
-        return amount / Double(weeks)
+        guard hasDeadline else { return 0 }
+        return GoalPace.requiredWeeklyPace(remaining: amount, deadline: deadline, now: Date()) ?? 0
     }
 
-    var monthlyPace: Double { weeklyPace * 4.33 }
+    var monthlyPace: Double { weeklyPace * GoalPace.weeksPerMonth }
 
-    func weeksBetweenNowAndDeadline() -> Int {
-        max(1, Calendar.current.dateComponents([.weekOfYear], from: Date(), to: deadline).weekOfYear ?? 78)
-    }
+    var canPlant: Bool { !name.trimmingCharacters(in: .whitespaces).isEmpty && amount > 0 }
 }
 
 // MARK: - Flow container
@@ -35,14 +37,22 @@ struct AddGoalFlowView: View {
     @StateObject private var state = AddGoalState()
     @State private var step = 1
     @State private var showSuccess = false
+    @State private var plantedGoal: GoalModel?
+    @State private var showDeposit = false
+    @State private var saveError: String?
 
     var body: some View {
         if showSuccess {
             AddGoalSuccessView(
                 state: state,
-                onDeposit: { isPresented = false },
+                onDeposit: { showDeposit = true },
                 onHome: { isPresented = false }
             )
+            .sheet(isPresented: $showDeposit, onDismiss: { isPresented = false }) {
+                if let goal = plantedGoal {
+                    DepositSheet(goal: goal, modelContext: modelContext)
+                }
+            }
         } else {
             Group {
                 switch step {
@@ -59,24 +69,35 @@ struct AddGoalFlowView: View {
                 removal: .move(edge: .leading)
             ))
             .animation(.spring(response: 0.35, dampingFraction: 0.85), value: step)
+            .alert("Couldn't save the goal", isPresented: Binding(get: { saveError != nil }, set: { if !$0 { saveError = nil } })) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text(saveError ?? "")
+            }
         }
     }
 
     private func plantGoal() {
-        guard !state.name.isEmpty, state.amount > 0 else { return }
+        guard state.canPlant else { return } // the button is disabled before this; belt and braces
         let goal = GoalModel(
-            name: state.name,
+            name: state.name.trimmingCharacters(in: .whitespaces),
             current: 0,
             target: state.amount,
             color: state.color,
             isFavorite: state.isFavorite,
             autoMoveEnabled: state.autoDeposit,
-            autoMoveAmount: state.monthlyPace.rounded(),
-            deadline: state.deadline
+            autoMoveAmount: state.hasDeadline ? state.monthlyPace.rounded() : 0,
+            deadline: state.hasDeadline ? state.deadline : nil
         )
         modelContext.insert(goal)
-        try? modelContext.save()
-        withAnimation(.easeInOut(duration: 0.4)) { showSuccess = true }
+        do {
+            try modelContext.save()
+            plantedGoal = goal
+            withAnimation(.easeInOut(duration: 0.4)) { showSuccess = true }
+        } catch {
+            modelContext.delete(goal)
+            saveError = "Please try again."
+        }
     }
 }
 
@@ -86,6 +107,7 @@ struct AddGoalHeader: View {
     let step: Int; let total: Int
     let onBack: () -> Void; let onSkip: () -> Void
     var showClose: Bool = false
+    var showSkip: Bool = true
 
     var body: some View {
         VStack(spacing: 0) {
@@ -106,11 +128,15 @@ struct AddGoalHeader: View {
                 + Text("\(step)").font(.system(size: 13, weight: .semibold)).foregroundColor(Color.warmInk)
                 + Text(" of \(total)").font(.system(size: 13)).foregroundColor(Color.warmInkMuted)
                 Spacer()
-                Button(action: onSkip) {
-                    Text("Skip")
-                        .font(.system(size: 13))
-                        .foregroundStyle(Color.warmInkMuted)
-                        .frame(width: 36, height: 36)
+                if showSkip {
+                    Button(action: onSkip) {
+                        Text("Skip")
+                            .font(.system(size: 13))
+                            .foregroundStyle(Color.warmInkMuted)
+                            .frame(width: 36, height: 36)
+                    }
+                } else {
+                    Color.clear.frame(width: 36, height: 36)
                 }
             }
             .padding(.horizontal, 20)
@@ -130,9 +156,8 @@ struct AddGoalHeader: View {
     }
 }
 
-// MARK: - Step 1: Intent — name, emoji, color
+// MARK: - Step 1: Intent — name, color
 
-private let goalEmojis = ["✈️", "🏡", "🌿", "🚗", "💍", "🎓", "🎁", "🏥"]
 
 struct AddGoalStep1View: View {
     @ObservedObject var state: AddGoalState
@@ -160,10 +185,7 @@ struct AddGoalStep1View: View {
                 HStack {
                     Spacer()
                     HStack(spacing: 12) {
-                        ZStack {
-                            Circle().fill(state.color.trackColor).frame(width: 44, height: 44)
-                            Text(state.emoji).font(.system(size: 22))
-                        }
+                        GoalInitialCircle(name: state.name, color: state.color, size: 44)
                         VStack(alignment: .leading, spacing: 2) {
                             Text(state.name.isEmpty ? "Your goal name" : state.name)
                                 .font(.system(size: 20, weight: .regular, design: .serif))
@@ -204,30 +226,6 @@ struct AddGoalStep1View: View {
                     )
                     Text("Tip: be specific. Try a specific name like Kyoto trip '26.")
                         .font(.system(size: 12)).foregroundStyle(Color.warmInkMuted).padding(.leading, 4)
-                }
-                .padding(.horizontal, 20).padding(.bottom, 24)
-
-                // Emoji picker
-                VStack(alignment: .leading, spacing: 10) {
-                    Text("SYMBOL")
-                        .font(.system(size: 11, weight: .semibold)).foregroundStyle(Color.warmInkMuted).tracking(0.8)
-                    LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 8), count: 8), spacing: 8) {
-                        ForEach(goalEmojis, id: \.self) { e in
-                            let isOn = state.emoji == e
-                            Button(action: { state.emoji = e }) {
-                                Text(e).font(.system(size: 20))
-                                    .frame(width: 44, height: 44)
-                                    .background(isOn ? state.color.trackColor : Color.warmSurface)
-                                    .cornerRadius(12)
-                                    .overlay(
-                                        RoundedRectangle(cornerRadius: 12)
-                                            .stroke(isOn ? state.color.color : Color.warmLine, lineWidth: isOn ? 1.5 : 1)
-                                    )
-                            }
-                            .buttonStyle(.plain)
-                            .animation(.easeInOut(duration: 0.15), value: state.emoji)
-                        }
-                    }
                 }
                 .padding(.horizontal, 20).padding(.bottom, 24)
 
@@ -291,10 +289,7 @@ struct AddGoalStep2View: View {
 
             // Goal name chip
             HStack(spacing: 10) {
-                ZStack {
-                    Circle().fill(state.color.trackColor).frame(width: 28, height: 28)
-                    Text(state.emoji).font(.system(size: 14))
-                }
+                GoalInitialCircle(name: state.name, color: state.color, size: 28)
                 Text(state.name)
                     .font(.system(size: 13)).foregroundStyle(Color.warmInkSoft)
             }
@@ -405,15 +400,17 @@ struct AddGoalStep3View: View {
                             .font(.system(size: 11, weight: .bold)).foregroundStyle(Color.warmOnGreen.opacity(0.85)).tracking(1.2)
                     }
                     HStack(alignment: .firstTextBaseline) {
-                        Text("$\(Int(state.weeklyPace))")
+                        Text(state.hasDeadline ? "$\(Int(state.weeklyPace))" : "—")
                             .font(.system(size: 38, weight: .regular, design: .serif)).foregroundStyle(Color.warmOnGreen)
                         Text("/wk")
                             .font(.system(size: 18)).foregroundStyle(Color.warmOnGreen.opacity(0.7)).padding(.leading, 2)
                         Spacer()
-                        Text("~$\(Int(state.monthlyPace))/mo")
+                        Text(state.hasDeadline ? "~$\(Int(state.monthlyPace))/mo" : "no date")
                             .font(.system(size: 13)).foregroundStyle(Color.warmOnGreen.opacity(0.85))
                     }
-                    Text("To hit **$\(Int(state.amount))** by **\(formattedDeadline)**.")
+                    Text(state.hasDeadline
+                         ? "To hit **$\(Int(state.amount))** by **\(formattedDeadline)**."
+                         : "No target date — save at your own pace.")
                         .font(.system(size: 13)).foregroundStyle(Color.warmOnGreen.opacity(0.85))
                 }
                 .padding(18)
@@ -421,8 +418,10 @@ struct AddGoalStep3View: View {
                 .cornerRadius(22)
                 .padding(.horizontal, 20).padding(.bottom, 16)
 
-                // Mini calendar
+                // Mini calendar — picking a day turns the date back on
                 MiniCalendarView(displayMonth: $displayMonth, selectedDate: $state.deadline)
+                    .opacity(state.hasDeadline ? 1 : 0.45)
+                    .onChange(of: state.deadline) { state.hasDeadline = true; selectedDuration = -2 }
                     .padding(.horizontal, 20).padding(.bottom, 14)
 
                 // Duration presets
@@ -433,10 +432,12 @@ struct AddGoalStep3View: View {
                             Button(action: {
                                 if let m = preset.months {
                                     selectedDuration = m
+                                    state.hasDeadline = true
                                     state.deadline = Calendar.current.date(byAdding: .month, value: m, to: Date()) ?? Date()
                                     displayMonth = state.deadline
                                 } else {
                                     selectedDuration = -1
+                                    state.hasDeadline = false
                                 }
                             }) {
                                 Text(preset.label)
@@ -463,11 +464,13 @@ struct AddGoalStep3View: View {
                     VStack(alignment: .leading, spacing: 2) {
                         Text("Auto-move on payday")
                             .font(.system(size: 14, weight: .semibold)).foregroundStyle(Color.warmInk)
-                        Text("Set $\(Int(state.monthlyPace)) aside the day after each paycheck.")
+                        Text(state.hasDeadline
+                             ? "Set $\(Int(state.monthlyPace)) aside the day after each paycheck."
+                             : "Pick the amount later in the goal's settings.")
                             .font(.system(size: 12)).foregroundStyle(Color.warmInkMuted)
                     }
                     Spacer()
-                    Toggle("", isOn: $state.autoDeposit)
+                    Toggle("Auto-move on payday", isOn: $state.autoDeposit)
                         .labelsHidden()
                         .tint(Color.warmGreen)
                 }
@@ -490,6 +493,7 @@ struct AddGoalStep3View: View {
     }
 
     private var formattedDeadline: String {
+        guard state.hasDeadline else { return "—" }
         let f = DateFormatter(); f.dateFormat = "MMM d, yyyy"
         return f.string(from: state.deadline)
     }
@@ -582,7 +586,7 @@ struct AddGoalStep4View: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
-                AddGoalHeader(step: 4, total: 4, onBack: onBack, onSkip: {})
+                AddGoalHeader(step: 4, total: 4, onBack: onBack, onSkip: {}, showSkip: false)
 
                 VStack(alignment: .leading, spacing: 10) {
                     Text("ALMOST THERE")
@@ -595,10 +599,7 @@ struct AddGoalStep4View: View {
                 // Hero preview card
                 VStack(alignment: .leading, spacing: 0) {
                     HStack(spacing: 12) {
-                        ZStack {
-                            Circle().fill(state.color.trackColor).frame(width: 44, height: 44)
-                            Text(state.emoji).font(.system(size: 22))
-                        }
+                        GoalInitialCircle(name: state.name, color: state.color, size: 44)
                         VStack(alignment: .leading, spacing: 3) {
                             Text(state.name)
                                 .font(.system(size: 22, weight: .regular, design: .serif)).foregroundStyle(Color.warmInk)
@@ -632,7 +633,9 @@ struct AddGoalStep4View: View {
                     .frame(height: 8).padding(.bottom, 14)
 
                     HStack(spacing: 6) {
-                        ForEach([("Per week","$\(Int(state.weeklyPace))"),("Per month","$\(Int(state.monthlyPace))"),("By",shortDeadline)], id: \.0) { item in
+                        ForEach([("Per week", state.hasDeadline ? "$\(Int(state.weeklyPace))" : "—"),
+                                 ("Per month", state.hasDeadline ? "$\(Int(state.monthlyPace))" : "—"),
+                                 ("By", shortDeadline)], id: \.0) { item in
                             VStack(spacing: 4) {
                                 Text(item.0)
                                     .font(.system(size: 9)).foregroundStyle(Color.warmInkMuted).textCase(.uppercase).tracking(0.8)
@@ -653,9 +656,7 @@ struct AddGoalStep4View: View {
 
                 // Recap toggles
                 VStack(spacing: 0) {
-                    RecapToggleRow(label: "Auto-move", sub: "On — $\(Int(state.monthlyPace)) each payday", isOn: $state.autoDeposit)
-                    Divider().padding(.horizontal, 16)
-                    RecapToggleRow(label: "Reminders", sub: "Friday mornings", isOn: $state.showReminders)
+                    RecapToggleRow(label: "Auto-move", sub: state.hasDeadline ? "On — $\(Int(state.monthlyPace)) each payday" : "On — amount set later", isOn: $state.autoDeposit)
                     Divider().padding(.horizontal, 16)
                     RecapToggleRow(label: "Favorite", sub: "Show on home screen", isOn: $state.isFavorite)
                 }
@@ -689,6 +690,8 @@ struct AddGoalStep4View: View {
                         .frame(maxWidth: .infinity).frame(height: 50)
                         .background(Color.warmGreenFill).cornerRadius(14)
                     }
+                    .disabled(!state.canPlant)
+                    .opacity(state.canPlant ? 1 : 0.4)
                     Button(action: onBack) {
                         Text("Edit anything")
                             .font(.system(size: 13)).foregroundStyle(Color.warmInkMuted)
@@ -702,9 +705,11 @@ struct AddGoalStep4View: View {
     }
 
     private var formattedDeadline: String {
+        guard state.hasDeadline else { return "No date" }
         let f = DateFormatter(); f.dateFormat = "MMM d, yyyy"; return f.string(from: state.deadline)
     }
     private var shortDeadline: String {
+        guard state.hasDeadline else { return "—" }
         let f = DateFormatter(); f.dateFormat = "MMM ''yy"; return f.string(from: state.deadline)
     }
 }
@@ -720,7 +725,7 @@ struct RecapToggleRow: View {
                 Text(sub).font(.system(size: 12)).foregroundStyle(Color.warmInkMuted)
             }
             Spacer()
-            Toggle("", isOn: $isOn).labelsHidden().tint(Color.warmGreen)
+            Toggle(label, isOn: $isOn).labelsHidden().tint(Color.warmGreen)
         }
         .padding(.horizontal, 16).padding(.vertical, 14)
     }
@@ -802,5 +807,23 @@ struct AddGoalSuccessView: View {
                 .padding(.horizontal, 28).padding(.bottom, 52)
             }
         }
+    }
+}
+
+// MARK: - Goal initial (the pattern WarmGoalCard / WarmQuickDepositView use)
+
+struct GoalInitialCircle: View {
+    let name: String
+    let color: GoalColor
+    let size: CGFloat
+
+    var body: some View {
+        ZStack {
+            Circle().fill(color.color).frame(width: size, height: size)
+            Text(name.first.map { String($0).uppercased() } ?? "·")
+                .font(.system(size: size * 0.5, weight: .regular, design: .serif))
+                .foregroundStyle(Color.warmOnGreen)
+        }
+        .accessibilityHidden(true)
     }
 }

--- a/Savely/Views/GoalsTab/GoalDetailView.swift
+++ b/Savely/Views/GoalsTab/GoalDetailView.swift
@@ -6,6 +6,15 @@ struct GoalDetailView: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(\.dismiss) private var dismiss
     @State private var showingEdit = false
+    @Query private var goalDeposits: [DepositModel]
+
+    init(goal: GoalModel) {
+        self.goal = goal
+        let goalID = goal.id
+        _goalDeposits = Query(filter: #Predicate<DepositModel> { $0.goalID == goalID })
+    }
+
+    private var pace: GoalPace { GoalPace.compute(goal: goal, deposits: goalDeposits) }
 
     var body: some View {
         ScrollView {
@@ -58,13 +67,25 @@ struct GoalDetailView: View {
                     }
                 }
                 .frame(width: 200, height: 200)
-                .padding(.bottom, 24)
+                .padding(.bottom, 12)
+
+                // — Status · deadline —
+                HStack(spacing: 6) {
+                    Circle()
+                        .fill(pace.status == .behind ? Color.warmClay : Color.warmGreen)
+                        .frame(width: 6, height: 6)
+                        .accessibilityHidden(true)
+                    Text(statusLine)
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(pace.status == .behind ? Color.warmClay : Color.warmInkSoft)
+                }
+                .padding(.bottom, 20)
 
                 // — Stat pills —
                 HStack(spacing: 8) {
                     StatPill(label: "Remaining", value: formattedAmount(max(0, goal.target - goal.current)), accent: goal.color)
-                    StatPill(label: "Per week", value: formattedAmount(perWeek), accent: goal.color)
-                    StatPill(label: "ETA", value: etaString, accent: goal.color)
+                    StatPill(label: "Needed / wk", value: pace.requiredWeekly.map { formattedAmount($0) } ?? "—", accent: goal.color)
+                    StatPill(label: "ETA", value: pace.etaText(), accent: goal.color)
                 }
                 .padding(.horizontal, 20)
                 .padding(.bottom, 20)
@@ -100,19 +121,12 @@ struct GoalDetailView: View {
         .sheet(isPresented: $showingEdit) { GoalEditSheet(goal: goal) }
     }
 
-    private var perWeek: Double {
-        let remaining = max(0, goal.target - goal.current)
-        return remaining / 24
-    }
-
-    private var etaString: String {
-        guard goal.progress < 1.0 else { return "Done!" }
-        let remaining = goal.target - goal.current
-        guard remaining > 0 else { return "Done!" }
-        let weeksLeft = remaining / max(1, perWeek)
-        let eta = Calendar.current.date(byAdding: .weekOfYear, value: Int(weeksLeft), to: Date()) ?? Date()
-        let f = DateFormatter(); f.dateFormat = "MMM d"
-        return f.string(from: eta)
+    /// "On track · by Jun 12" / "Behind · by Jun 12" / "On track · no target date" / "Complete!"
+    private var statusLine: String {
+        if pace.status == .complete { return pace.label }
+        guard let deadline = goal.deadline else { return "\(pace.label) · no target date" }
+        let f = DateFormatter(); f.dateFormat = "MMM d, yyyy"
+        return "\(pace.label) · by \(f.string(from: deadline)) · \(formattedAmount(pace.actualWeekly))/wk"
     }
 
     private func formattedAmount(_ v: Double) -> String {

--- a/Savely/Views/GoalsTab/GoalDetailView.swift
+++ b/Savely/Views/GoalsTab/GoalDetailView.swift
@@ -71,6 +71,11 @@ struct GoalDetailView: View {
                 // — Deposit card —
                 DepositCard(goal: goal, modelContext: modelContext)
                     .padding(.horizontal, 20)
+                    .padding(.bottom, 20)
+
+                // — History —
+                DepositHistorySection(goalID: goal.id)
+                    .padding(.horizontal, 20)
                     .padding(.bottom, 32)
             }
         }
@@ -147,6 +152,7 @@ struct DepositCard: View {
     let modelContext: ModelContext
     @State private var amountText = ""
     @State private var note = ""
+    @State private var errorMessage: String?
     private let quickAmounts: [Double] = [25, 50, 100, 250]
 
     var body: some View {
@@ -228,6 +234,11 @@ struct DepositCard: View {
         .cornerRadius(24)
         .overlay(RoundedRectangle(cornerRadius: 24).stroke(Color.warmLine, lineWidth: 1))
         .shadow(color: Color.warmShadow, radius: 16, x: 0, y: 8)
+        .alert("Couldn't save the deposit", isPresented: Binding(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(errorMessage ?? "")
+        }
     }
 
     private var depositAmount: Double? { Double(amountText) }
@@ -235,9 +246,127 @@ struct DepositCard: View {
 
     private func saveDeposit() {
         guard let amt = depositAmount, amt > 0 else { return }
-        goal.current = min(goal.current + amt, goal.target)
-        try? modelContext.save()
-        amountText = ""
-        note = ""
+        do {
+            try GoalDeposits.record(goal: goal, amount: amt, note: note, source: .manual, context: modelContext)
+            amountText = ""
+            note = ""
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+// MARK: - Deposit history
+
+/// Every deposit into this goal, newest first. Auto-move rows carry a small
+/// tag so the user can tell what they moved by hand from what payday moved.
+struct DepositHistorySection: View {
+    let goalID: UUID
+    @Query private var deposits: [DepositModel]
+
+    init(goalID: UUID) {
+        self.goalID = goalID
+        _deposits = Query(
+            filter: #Predicate<DepositModel> { $0.goalID == goalID },
+            sort: [SortDescriptor(\DepositModel.date, order: .reverse)]
+        )
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("History")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(Color.warmInkMuted)
+                .tracking(1)
+                .textCase(.uppercase)
+                .padding(.leading, 4)
+                .accessibilityAddTraits(.isHeader)
+
+            if deposits.isEmpty {
+                Text("No deposits yet — the first one lands here.")
+                    .font(.system(size: 13))
+                    .foregroundStyle(Color.warmInkSoft)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 14).padding(.vertical, 18)
+                    .background(Color.warmSurface)
+                    .cornerRadius(16)
+                    .overlay(RoundedRectangle(cornerRadius: 16).stroke(Color.warmLine, lineWidth: 1))
+            } else {
+                VStack(spacing: 0) {
+                    ForEach(Array(deposits.enumerated()), id: \.element.id) { idx, deposit in
+                        DepositRow(deposit: deposit)
+                        if idx < deposits.count - 1 {
+                            Divider().padding(.leading, 58).overlay(Color.warmLineSoft)
+                        }
+                    }
+                }
+                .background(Color.warmSurface)
+                .cornerRadius(16)
+                .overlay(RoundedRectangle(cornerRadius: 16).stroke(Color.warmLine, lineWidth: 1))
+            }
+        }
+    }
+}
+
+struct DepositRow: View {
+    let deposit: DepositModel
+
+    private var isAuto: Bool { deposit.source == DepositSource.autoMove.rawValue }
+
+    var body: some View {
+        HStack(spacing: 12) {
+            RoundedRectangle(cornerRadius: 10)
+                .fill(Color.warmGreenSoft)
+                .frame(width: 36, height: 36)
+                .overlay(
+                    Image(systemName: isAuto ? "sparkles" : "arrow.down.to.line")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundStyle(Color.warmGreen)
+                )
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Text(relativeDate(deposit.date))
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(Color.warmInk)
+                    if isAuto {
+                        Text("AUTO")
+                            .font(.system(size: 9, weight: .bold))
+                            .foregroundStyle(Color.warmGreenDeep)
+                            .tracking(0.6)
+                            .padding(.horizontal, 6).padding(.vertical, 2)
+                            .background(Color.warmGreenSoft)
+                            .clipShape(Capsule())
+                    }
+                }
+                if let note = deposit.note {
+                    Text(note)
+                        .font(.system(size: 12))
+                        .foregroundStyle(Color.warmInkSoft)
+                        .lineLimit(2)
+                }
+            }
+            Spacer()
+            Text("+\(formattedAmount(deposit.amount))")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(Color.warmGreen)
+                .monospacedDigit()
+        }
+        .padding(.horizontal, 14).padding(.vertical, 12)
+        .accessibilityElement(children: .combine)
+    }
+
+    private func relativeDate(_ d: Date) -> String {
+        let cal = Calendar.current
+        if cal.isDateInToday(d) { return "Today" }
+        if cal.isDateInYesterday(d) { return "Yesterday" }
+        let f = DateFormatter(); f.dateFormat = "MMM d, yyyy"
+        return f.string(from: d)
+    }
+
+    private func formattedAmount(_ v: Double) -> String {
+        let f = NumberFormatter(); f.numberStyle = .currency; f.currencySymbol = "$"; f.maximumFractionDigits = 2
+        return f.string(from: NSNumber(value: v)) ?? "$0"
     }
 }

--- a/Savely/Views/GoalsTab/GoalDetailView.swift
+++ b/Savely/Views/GoalsTab/GoalDetailView.swift
@@ -5,6 +5,7 @@ struct GoalDetailView: View {
     @Bindable var goal: GoalModel
     @Environment(\.modelContext) private var modelContext
     @Environment(\.dismiss) private var dismiss
+    @State private var showingEdit = false
 
     var body: some View {
         ScrollView {
@@ -84,7 +85,7 @@ struct GoalDetailView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
-                Button(action: {}) {
+                Button(action: { showingEdit = true }) {
                     Image(systemName: "pencil")
                         .font(.system(size: 14))
                         .foregroundStyle(Color.warmInk)
@@ -93,8 +94,10 @@ struct GoalDetailView: View {
                         .cornerRadius(12)
                         .overlay(RoundedRectangle(cornerRadius: 12).stroke(Color.warmLine, lineWidth: 1))
                 }
+                .accessibilityLabel("Edit goal")
             }
         }
+        .sheet(isPresented: $showingEdit) { GoalEditSheet(goal: goal) }
     }
 
     private var perWeek: Double {

--- a/Savely/Views/GoalsTab/GoalEditSheet.swift
+++ b/Savely/Views/GoalsTab/GoalEditSheet.swift
@@ -1,0 +1,221 @@
+//
+//  GoalEditSheet.swift
+//  Savely
+//
+//  Edit an existing goal: name, target, color (all thirteen), deadline
+//  (optional), payday auto-move. One explicit Save; validation errors are
+//  shown, never swallowed. Presented as a sheet from GoalDetailView's
+//  pencil and from the Dashboard hero card's pencil.
+//
+
+import SwiftUI
+import SwiftData
+
+struct GoalEditSheet: View {
+    @Bindable var goal: GoalModel
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var draft: GoalEditDraft
+    @State private var targetText: String
+    @State private var autoMoveText: String
+    @State private var color: GoalColor
+    @State private var errorMessage: String?
+
+    init(goal: GoalModel) {
+        self.goal = goal
+        let deadline = goal.deadline ?? Calendar.current.date(byAdding: .month, value: 6, to: Date()) ?? Date()
+        _draft = State(initialValue: GoalEditDraft(
+            name: goal.name,
+            target: goal.target,
+            hasDeadline: goal.deadline != nil,
+            deadline: deadline,
+            autoMoveEnabled: goal.autoMoveEnabled,
+            autoMoveAmount: goal.autoMoveAmount
+        ))
+        _targetText = State(initialValue: Self.plainNumber(goal.target))
+        _autoMoveText = State(initialValue: Self.plainNumber(goal.autoMoveAmount))
+        _color = State(initialValue: GoalColor(rawValue: goal.colorRawValue) ?? .green)
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 14) {
+                    // — Name & target —
+                    card {
+                        fieldRow(label: "Name") {
+                            TextField("Goal name", text: $draft.name)
+                                .font(.system(size: 15))
+                                .foregroundStyle(Color.warmInk)
+                                .multilineTextAlignment(.trailing)
+                        }
+                        WarmDivider()
+                        fieldRow(label: "Target") {
+                            HStack(spacing: 2) {
+                                Text("$").foregroundStyle(Color.warmInkMuted)
+                                TextField("0", text: $targetText)
+                                    .keyboardType(.decimalPad)
+                                    .font(.system(size: 15))
+                                    .foregroundStyle(Color.warmInk)
+                                    .monospacedDigit()
+                                    .multilineTextAlignment(.trailing)
+                                    .frame(width: 110)
+                                    .onChange(of: targetText) { draft.target = parseAmount(targetText) ?? 0 }
+                            }
+                        }
+                    }
+
+                    // — Color —
+                    VStack(alignment: .leading, spacing: 10) {
+                        sectionLabel("Color")
+                        LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 12), count: 7), spacing: 12) {
+                            ForEach(GoalColor.allCases) { gc in
+                                let isOn = color == gc
+                                Button(action: { color = gc }) {
+                                    Circle()
+                                        .fill(gc.color)
+                                        .frame(width: 36, height: 36)
+                                        .overlay(Circle().stroke(Color.warmSurface, lineWidth: isOn ? 3 : 0))
+                                        .overlay(Circle().stroke(isOn ? Color.warmInk : Color.clear, lineWidth: 1.5))
+                                }
+                                .buttonStyle(.plain)
+                                .accessibilityLabel(gc.displayName)
+                                .accessibilityAddTraits(isOn ? .isSelected : [])
+                            }
+                        }
+                        .padding(14)
+                        .background(Color.warmSurface)
+                        .cornerRadius(16)
+                        .overlay(RoundedRectangle(cornerRadius: 16).stroke(Color.warmLine, lineWidth: 1))
+                    }
+
+                    // — Deadline —
+                    VStack(alignment: .leading, spacing: 10) {
+                        sectionLabel("Timing")
+                        card {
+                            toggleRow("Target date", isOn: $draft.hasDeadline)
+                            if draft.hasDeadline {
+                                WarmDivider()
+                                fieldRow(label: "By") {
+                                    DatePicker("Target date", selection: $draft.deadline, in: Date()..., displayedComponents: .date)
+                                        .labelsHidden()
+                                        .tint(Color.warmGreen)
+                                }
+                            }
+                        }
+                    }
+
+                    // — Auto-move —
+                    VStack(alignment: .leading, spacing: 10) {
+                        sectionLabel("Payday")
+                        card {
+                            toggleRow("Auto-move on payday", isOn: $draft.autoMoveEnabled)
+                            if draft.autoMoveEnabled {
+                                WarmDivider()
+                                fieldRow(label: "Amount each payday") {
+                                    HStack(spacing: 2) {
+                                        Text("$").foregroundStyle(Color.warmInkMuted)
+                                        TextField("0", text: $autoMoveText)
+                                            .keyboardType(.decimalPad)
+                                            .font(.system(size: 15))
+                                            .foregroundStyle(Color.warmInk)
+                                            .monospacedDigit()
+                                            .multilineTextAlignment(.trailing)
+                                            .frame(width: 90)
+                                            .onChange(of: autoMoveText) { draft.autoMoveAmount = parseAmount(autoMoveText) ?? 0 }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    Spacer(minLength: 16)
+                }
+                .padding(.horizontal, 20)
+                .padding(.top, 8)
+                .padding(.bottom, 24)
+            }
+            .background(Color.warmBg)
+            .navigationTitle("Edit goal")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }.foregroundStyle(Color.warmInkSoft)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") { save() }.fontWeight(.semibold).foregroundStyle(Color.warmGreen)
+                }
+            }
+            .alert("Can't save yet", isPresented: Binding(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text(errorMessage ?? "")
+            }
+        }
+        .presentationDetents([.large])
+        .presentationDragIndicator(.visible)
+    }
+
+    // MARK: - Save
+
+    private func save() {
+        if let error = GoalEditValidation.firstError(in: draft, current: goal.current) {
+            errorMessage = error.localizedDescription
+            return
+        }
+        goal.name = draft.trimmedName
+        goal.target = draft.target
+        goal.colorRawValue = color.rawValue
+        goal.deadline = draft.hasDeadline ? draft.deadline : nil
+        goal.autoMoveEnabled = draft.autoMoveEnabled
+        goal.autoMoveAmount = draft.autoMoveEnabled ? draft.autoMoveAmount : goal.autoMoveAmount
+        do {
+            try modelContext.save()
+            dismiss()
+        } catch {
+            errorMessage = "Couldn't save the goal. Please try again."
+        }
+    }
+
+    // MARK: - Pieces
+
+    private func card<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+        VStack(spacing: 0) { content() }
+            .background(Color.warmSurface)
+            .cornerRadius(16)
+            .overlay(RoundedRectangle(cornerRadius: 16).stroke(Color.warmLine, lineWidth: 1))
+    }
+
+    private func sectionLabel(_ text: String) -> some View {
+        Text(text.uppercased())
+            .font(.system(size: 11, weight: .semibold))
+            .foregroundStyle(Color.warmInkMuted)
+            .tracking(0.8)
+            .padding(.leading, 4)
+            .accessibilityAddTraits(.isHeader)
+    }
+
+    private func fieldRow<Content: View>(label: String, @ViewBuilder content: () -> Content) -> some View {
+        HStack(spacing: 16) {
+            Text(label)
+                .font(.system(size: 14, weight: .medium))
+                .foregroundStyle(Color.warmInk)
+            Spacer(minLength: 12)
+            content()
+        }
+        .padding(.horizontal, 16).padding(.vertical, 12)
+    }
+
+    private func toggleRow(_ title: String, isOn: Binding<Bool>) -> some View {
+        Toggle(isOn: isOn) {
+            Text(title).font(.system(size: 14, weight: .medium)).foregroundStyle(Color.warmInk)
+        }
+        .tint(Color.warmGreen)
+        .padding(.horizontal, 16).padding(.vertical, 12)
+    }
+
+    private static func plainNumber(_ value: Double) -> String {
+        value == value.rounded() ? String(Int(value)) : String(value)
+    }
+}

--- a/Savely/Views/GoalsTab/GoalsView.swift
+++ b/Savely/Views/GoalsTab/GoalsView.swift
@@ -8,6 +8,10 @@ struct GoalsView: View {
 
     private var totalSaved:    Double { viewModel.goals.reduce(0) { $0 + $1.current } }
     private var totalTarget:   Double { viewModel.goals.reduce(0) { $0 + $1.target } }
+    private var activeGoals:    [GoalModel] { viewModel.goals.filter { $0.progress < 1 } }
+    private var completedGoals: [GoalModel] { viewModel.goals.filter { $0.progress >= 1 } }
+    @State private var celebrating: Set<UUID> = []
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     private var overallProgress: Double { totalTarget > 0 ? min(totalSaved / totalTarget, 1.0) : 0 }
 
     var body: some View {
@@ -43,7 +47,7 @@ struct GoalsView: View {
                         Text("Goals")
                             .font(.system(size: 34, weight: .regular, design: .serif))
                             .foregroundStyle(Color.warmInk)
-                        Text("\(viewModel.goals.count) active · \(formattedAmount(totalSaved)) saved of \(formattedAmount(totalTarget))")
+                        Text("\(activeGoals.count) active · \(formattedAmount(totalSaved)) saved of \(formattedAmount(totalTarget))")
                             .font(.system(size: 14)).foregroundStyle(Color.warmInkMuted)
                     }
                     Spacer()
@@ -81,21 +85,63 @@ struct GoalsView: View {
                 .overlay(RoundedRectangle(cornerRadius: 18).stroke(Color.warmLine, lineWidth: 1))
 
                 VStack(spacing: 12) {
-                    ForEach(viewModel.goals) { goal in
-                        NavigationLink(destination: GoalDetailView(goal: goal)) {
-                            WarmGoalCard(
-                                goal: goal,
-                                onFavoriteToggle: { viewModel.setFavorite(goal: goal) },
-                                onDelete: { viewModel.deleteGoal(goal) }
-                            )
-                        }
-                        .buttonStyle(.plain)
+                    ForEach(activeGoals) { goal in
+                        goalLink(goal)
                     }
+                }
+
+                // — Completed — out of the active count, one-time celebration
+                if !completedGoals.isEmpty {
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("Completed")
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundStyle(Color.warmInkMuted)
+                            .tracking(1)
+                            .textCase(.uppercase)
+                            .padding(.leading, 4)
+                            .accessibilityAddTraits(.isHeader)
+                        ForEach(completedGoals) { goal in
+                            goalLink(goal)
+                                .scaleEffect(celebrating.contains(goal.id) ? 1.03 : 1)
+                                .shadow(
+                                    color: Color.warmAmber.opacity(celebrating.contains(goal.id) ? 0.45 : 0),
+                                    radius: celebrating.contains(goal.id) ? 14 : 0
+                                )
+                                .animation(.spring(response: 0.4, dampingFraction: 0.8), value: celebrating)
+                        }
+                    }
+                    .padding(.top, 8)
                 }
 
                 Spacer(minLength: 16)
             }
             .padding(.horizontal, 20).padding(.bottom, 24)
+        }
+        .onAppear { celebrateNewCompletions() }
+        .onChange(of: completedGoals.map(\.id)) { celebrateNewCompletions() }
+    }
+
+    private func goalLink(_ goal: GoalModel) -> some View {
+        NavigationLink(destination: GoalDetailView(goal: goal)) {
+            WarmGoalCard(
+                goal: goal,
+                onFavoriteToggle: { viewModel.setFavorite(goal: goal) },
+                onDelete: { viewModel.deleteGoal(goal) }
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    /// Pops a just-completed goal once, then remembers it (mirrors
+    /// AchievementStore). Reduce Motion: no pop, still remembered.
+    private func celebrateNewCompletions() {
+        let fresh = GoalCelebrationStore.newlyCompleted(completedGoals)
+        guard !fresh.isEmpty else { return }
+        GoalCelebrationStore.markCelebrated(completedGoals)
+        guard !reduceMotion else { return }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+            celebrating = fresh
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.4) { celebrating = [] }
         }
     }
 
@@ -213,6 +259,17 @@ struct WarmGoalCard: View {
     let onFavoriteToggle: () -> Void
     let onDelete: () -> Void
     @State private var showDeleteConfirmation = false
+    @Query private var goalDeposits: [DepositModel]
+
+    init(goal: GoalModel, onFavoriteToggle: @escaping () -> Void, onDelete: @escaping () -> Void) {
+        self.goal = goal
+        self.onFavoriteToggle = onFavoriteToggle
+        self.onDelete = onDelete
+        let goalID = goal.id
+        _goalDeposits = Query(filter: #Predicate<DepositModel> { $0.goalID == goalID })
+    }
+
+    private var pace: GoalPace { GoalPace.compute(goal: goal, deposits: goalDeposits) }
 
     var body: some View {
         VStack(spacing: 12) {
@@ -231,8 +288,9 @@ struct WarmGoalCard: View {
                             Image(systemName: "star.fill").font(.system(size: 12)).foregroundStyle(Color.warmAmber)
                         }
                     }
-                    Text(paceText)
-                        .font(.system(size: 12)).foregroundStyle(Color.warmInkMuted)
+                    Text(pace.label)
+                        .font(.system(size: 12))
+                        .foregroundStyle(pace.status == .behind ? Color.warmClay : Color.warmInkMuted)
                 }
                 Spacer()
                 VStack(alignment: .trailing, spacing: 2) {
@@ -277,10 +335,6 @@ struct WarmGoalCard: View {
         } message: {
             Text("Are you sure you want to delete this goal?")
         }
-    }
-
-    private var paceText: String {
-        goal.progress >= 1.0 ? "Complete!" : goal.progress > 0.5 ? "On track" : "In progress"
     }
 
     private func formattedAmount(_ v: Double) -> String {

--- a/Savely/Views/MainNavigationView.swift
+++ b/Savely/Views/MainNavigationView.swift
@@ -397,6 +397,9 @@ struct WarmQuickExpenseView: View {
             WarmKeypad(amountStr: $amountStr)
         }
         .onAppear { vm.setModelContext(modelContext) }
+        .alert(isPresented: $vm.showError) {
+            Alert(title: Text(Strings.Errors.errorLabel), message: Text(vm.errorMessage), dismissButton: .default(Text(Strings.Buttons.okButton)))
+        }
     }
 
     private func saveAndDismiss() {
@@ -415,6 +418,7 @@ struct WarmQuickIncomeView: View {
     @Query private var goals: [GoalModel]
     @Query private var allIncomes: [IncomeModel]
     @Query private var allExpenses: [ExpenseModel]
+    @Query private var allDeposits: [DepositModel]
     let onBack: () -> Void; let onSave: () -> Void
 
     @State private var amountStr = "0"
@@ -445,7 +449,8 @@ struct WarmQuickIncomeView: View {
             goals: goals,
             incomeAmount: enteredAmount,
             monthIncomeTotal: monthTotal(allIncomes.map { ($0.date, $0.amount) }),
-            monthExpenseTotal: monthTotal(allExpenses.map { ($0.date, $0.amount) })
+            monthExpenseTotal: monthTotal(allExpenses.map { ($0.date, $0.amount) }),
+            monthDepositTotal: GoalDeposits.monthTotal(allDeposits)
         )
     }
 
@@ -540,6 +545,9 @@ struct WarmQuickIncomeView: View {
             WarmKeypad(amountStr: $amountStr)
         }
         .onAppear { vm.setModelContext(modelContext) }
+        .alert(isPresented: $vm.showError) {
+            Alert(title: Text(Strings.Errors.errorLabel), message: Text(vm.errorMessage), dismissButton: .default(Text(Strings.Buttons.okButton)))
+        }
     }
 
     private func bannerText(for suggestion: AutoMoveSuggestion) -> AttributedString {
@@ -560,8 +568,18 @@ struct WarmQuickIncomeView: View {
         vm.amount = amountStr
         vm.addIncome(source: selectedSource)
         if let suggestion = armedSuggestion {
-            suggestion.apply()
-            try? modelContext.save()
+            do {
+                try GoalDeposits.record(
+                    goal: suggestion.goal, amount: suggestion.amount,
+                    note: "Payday auto-move", source: .autoMove, context: modelContext
+                )
+            } catch {
+                // The income itself is already saved; the move failing must
+                // not lose it. Surface through the income VM's alert.
+                vm.errorMessage = "Income saved, but the auto-move to \(suggestion.goal.name) failed."
+                vm.showError = true
+                return
+            }
         }
         onSave()
     }
@@ -576,6 +594,7 @@ struct WarmQuickDepositView: View {
 
     @State private var selectedGoal: GoalModel?
     @State private var selectedPreset: Double = 50
+    @State private var errorMessage: String?
     private let presets: [Double] = [25, 50, 100, 250]
 
     var body: some View {
@@ -712,13 +731,21 @@ struct WarmQuickDepositView: View {
                 selectedGoal = goals.first(where: { $0.isFavorite }) ?? goals.first
             }
         }
+        .alert("Couldn't save the deposit", isPresented: Binding(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(errorMessage ?? "")
+        }
     }
 
     private func saveDeposit() {
         guard let goal = selectedGoal, selectedPreset > 0 else { return }
-        goal.current = min(goal.current + selectedPreset, goal.target)
-        try? modelContext.save()
-        onSave()
+        do {
+            try GoalDeposits.record(goal: goal, amount: selectedPreset, source: .manual, context: modelContext)
+            onSave()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
     }
 }
 

--- a/SavelyTests/AutoMoveSuggestionTests.swift
+++ b/SavelyTests/AutoMoveSuggestionTests.swift
@@ -83,20 +83,6 @@ final class AutoMoveSuggestionTests: XCTestCase {
         XCTAssertEqual(s.goal.name, "Behind")
     }
 
-    func testApplyClampsAtTarget() {
-        let g = goal("Trip", target: 1000, current: 950, pace: 100)
-        let s = AutoMoveSuggestion(goal: g, amount: 100)
-        s.apply()
-        XCTAssertEqual(g.current, 1000)
-    }
-
-    func testApplyAddsAmount() {
-        let g = goal("Trip", target: 1000, current: 200, pace: 100)
-        let s = AutoMoveSuggestion(goal: g, amount: 100)
-        s.apply()
-        XCTAssertEqual(g.current, 300)
-    }
-
     // MARK: - Deadline urgency priority
 
     func testMoreUrgentDeadlineWins() throws {
@@ -157,5 +143,27 @@ final class AutoMoveSuggestionTests: XCTestCase {
             monthIncomeTotal: 2000, monthExpenseTotal: 800
         ))
         XCTAssertEqual(s.amount, 100)
+    }
+
+    // MARK: - Month margin subtracts money already moved into goals
+
+    func testMonthDepositsReduceTheMargin() throws {
+        let g = goal("Trip", target: 1000, current: 0, favorite: true, pace: 300)
+        // Month so far: 500 in, 100 out, and 350 already deposited into goals.
+        // Logging 100 more: margin = 500 + 100 - 100 - 350 = 150 → capped at 150.
+        let s = try XCTUnwrap(AutoMoveSuggestion.compute(
+            goals: [g], incomeAmount: 100, monthIncomeTotal: 500,
+            monthExpenseTotal: 100, monthDepositTotal: 350, now: now, calendar: calendar
+        ))
+        XCTAssertEqual(s.amount, 100) // also capped by the income being logged
+        let s2 = try XCTUnwrap(AutoMoveSuggestion.compute(
+            goals: [g], incomeAmount: 400, monthIncomeTotal: 500,
+            monthExpenseTotal: 100, monthDepositTotal: 350, now: now, calendar: calendar
+        ))
+        XCTAssertEqual(s2.amount, 300) // pace cap: margin is 450, pace is 300
+        XCTAssertNil(AutoMoveSuggestion.compute(
+            goals: [g], incomeAmount: 100, monthIncomeTotal: 500,
+            monthExpenseTotal: 100, monthDepositTotal: 600, now: now, calendar: calendar
+        )) // deposits already ate the month: 500 + 100 - 100 - 600 < 0
     }
 }

--- a/SavelyTests/GoalDepositsTests.swift
+++ b/SavelyTests/GoalDepositsTests.swift
@@ -1,0 +1,91 @@
+//
+//  GoalDepositsTests.swift
+//  SavelyTests
+//
+
+import XCTest
+import SwiftData
+@testable import Savely
+
+@MainActor
+final class GoalDepositsTests: XCTestCase {
+    private var container: ModelContainer!
+    private var context: ModelContext!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        container = try ModelContainer(for: GoalModel.self, DepositModel.self, configurations: config)
+        context = ModelContext(container)
+    }
+
+    override func tearDownWithError() throws {
+        context = nil
+        container = nil
+        try super.tearDownWithError()
+    }
+
+    private func makeGoal(target: Double, current: Double = 0) -> GoalModel {
+        let goal = GoalModel(name: "Trip", current: current, target: target, color: .green)
+        context.insert(goal)
+        return goal
+    }
+
+    // Migrated from AutoMoveSuggestionTests.testApplyAddsAmount / testApplyClampsAtTarget
+
+    func testRecordAddsAmountToTheGoal() throws {
+        let goal = makeGoal(target: 1000, current: 200)
+        try GoalDeposits.record(goal: goal, amount: 100, source: .manual, context: context)
+        XCTAssertEqual(goal.current, 300)
+    }
+
+    func testRecordClampsAtTarget() throws {
+        let goal = makeGoal(target: 1000, current: 950)
+        try GoalDeposits.record(goal: goal, amount: 100, source: .autoMove, context: context)
+        XCTAssertEqual(goal.current, 1000)
+    }
+
+    // MARK: - Ledger
+
+    func testRecordInsertsALedgerRowWithIntentNotClampedDelta() throws {
+        let goal = makeGoal(target: 1000, current: 950)
+        try GoalDeposits.record(goal: goal, amount: 100, note: "  bonus  ", source: .autoMove, context: context)
+
+        let rows = try context.fetch(FetchDescriptor<DepositModel>())
+        XCTAssertEqual(rows.count, 1)
+        let row = try XCTUnwrap(rows.first)
+        XCTAssertEqual(row.goalID, goal.id)
+        XCTAssertEqual(row.amount, 100)          // what was asked for
+        XCTAssertEqual(row.note, "bonus")        // trimmed
+        XCTAssertEqual(row.source, DepositSource.autoMove.rawValue)
+    }
+
+    func testEmptyNoteIsStoredAsNil() throws {
+        let goal = makeGoal(target: 100)
+        try GoalDeposits.record(goal: goal, amount: 10, note: "   ", source: .manual, context: context)
+        XCTAssertNil(try XCTUnwrap(try context.fetch(FetchDescriptor<DepositModel>()).first).note)
+    }
+
+    func testNonPositiveAmountThrowsAndWritesNothing() throws {
+        let goal = makeGoal(target: 100, current: 10)
+        XCTAssertThrowsError(try GoalDeposits.record(goal: goal, amount: 0, source: .manual, context: context))
+        XCTAssertThrowsError(try GoalDeposits.record(goal: goal, amount: -5, source: .manual, context: context))
+        XCTAssertEqual(goal.current, 10)
+        XCTAssertTrue(try context.fetch(FetchDescriptor<DepositModel>()).isEmpty)
+    }
+
+    // MARK: - Month total
+
+    func testMonthTotalCountsOnlyThisCalendarMonth() throws {
+        let calendar = Calendar(identifier: .gregorian)
+        let now = Date(timeIntervalSince1970: 1_784_000_000)
+        let lastMonth = try XCTUnwrap(calendar.date(byAdding: .month, value: -1, to: now))
+        let goalID = UUID()
+        let rows = [
+            DepositModel(goalID: goalID, amount: 100, date: now, source: .manual),
+            DepositModel(goalID: goalID, amount: 50, date: now, source: .autoMove),
+            DepositModel(goalID: goalID, amount: 999, date: lastMonth, source: .manual),
+        ]
+        XCTAssertEqual(GoalDeposits.monthTotal(rows, now: now, calendar: calendar), 150)
+    }
+}

--- a/SavelyTests/GoalEditValidationTests.swift
+++ b/SavelyTests/GoalEditValidationTests.swift
@@ -1,0 +1,70 @@
+//
+//  GoalEditValidationTests.swift
+//  SavelyTests
+//
+
+import XCTest
+@testable import Savely
+
+final class GoalEditValidationTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_784_000_000)
+    private var future: Date { now.addingTimeInterval(86_400 * 30) }
+    private var past: Date { now.addingTimeInterval(-86_400) }
+
+    private func draft(
+        name: String = "Trip", target: Double = 1000, hasDeadline: Bool = false,
+        deadline: Date? = nil, autoMove: Bool = false, autoAmount: Double = 100
+    ) -> GoalEditDraft {
+        GoalEditDraft(
+            name: name, target: target, hasDeadline: hasDeadline,
+            deadline: deadline ?? future, autoMoveEnabled: autoMove, autoMoveAmount: autoAmount
+        )
+    }
+
+    func testValidDraftHasNoError() {
+        XCTAssertNil(GoalEditValidation.firstError(in: draft(), current: 0, now: now))
+        XCTAssertNil(GoalEditValidation.firstError(in: draft(hasDeadline: true, autoMove: true), current: 500, now: now))
+    }
+
+    func testEmptyOrWhitespaceNameIsRejected() {
+        XCTAssertEqual(GoalEditValidation.firstError(in: draft(name: ""), current: 0, now: now), .emptyName)
+        XCTAssertEqual(GoalEditValidation.firstError(in: draft(name: "   "), current: 0, now: now), .emptyName)
+    }
+
+    func testTargetMustBePositive() {
+        XCTAssertEqual(GoalEditValidation.firstError(in: draft(target: 0), current: 0, now: now), .nonPositiveTarget)
+        XCTAssertEqual(GoalEditValidation.firstError(in: draft(target: -1), current: 0, now: now), .nonPositiveTarget)
+    }
+
+    func testTargetCannotDropBelowSavedMoney() {
+        XCTAssertEqual(
+            GoalEditValidation.firstError(in: draft(target: 400), current: 500, now: now),
+            .targetBelowSaved(saved: 500)
+        )
+        // Equal is fine — that is a completed goal.
+        XCTAssertNil(GoalEditValidation.firstError(in: draft(target: 500), current: 500, now: now))
+    }
+
+    func testDeadlineMustBeInTheFutureOnlyWhenEnabled() {
+        XCTAssertEqual(
+            GoalEditValidation.firstError(in: draft(hasDeadline: true, deadline: past), current: 0, now: now),
+            .deadlineInPast
+        )
+        // Date off → a stale past date in the draft is irrelevant.
+        XCTAssertNil(GoalEditValidation.firstError(in: draft(hasDeadline: false, deadline: past), current: 0, now: now))
+    }
+
+    func testAutoMoveAmountMustBePositiveOnlyWhenEnabled() {
+        XCTAssertEqual(
+            GoalEditValidation.firstError(in: draft(autoMove: true, autoAmount: 0), current: 0, now: now),
+            .nonPositiveAutoMove
+        )
+        XCTAssertNil(GoalEditValidation.firstError(in: draft(autoMove: false, autoAmount: 0), current: 0, now: now))
+    }
+
+    func testRulesAreCheckedInOrderNameFirst() {
+        // Everything wrong at once → the first (name) is what the user hears.
+        let bad = draft(name: "", target: 0, hasDeadline: true, deadline: past, autoMove: true, autoAmount: 0)
+        XCTAssertEqual(GoalEditValidation.firstError(in: bad, current: 10, now: now), .emptyName)
+    }
+}

--- a/SavelyTests/GoalPaceTests.swift
+++ b/SavelyTests/GoalPaceTests.swift
@@ -1,0 +1,109 @@
+//
+//  GoalPaceTests.swift
+//  SavelyTests
+//
+
+import XCTest
+@testable import Savely
+
+final class GoalPaceTests: XCTestCase {
+    private let calendar = Calendar(identifier: .gregorian)
+    private let now = Date(timeIntervalSince1970: 1_784_000_000)
+
+    private func goal(target: Double, current: Double = 0, weeksToDeadline: Int? = nil,
+                      autoMove: Bool = false, autoAmount: Double = 0) -> GoalModel {
+        let deadline = weeksToDeadline.flatMap { calendar.date(byAdding: .weekOfYear, value: $0, to: now) }
+        return GoalModel(name: "G", current: current, target: target, color: .green,
+                         autoMoveEnabled: autoMove, autoMoveAmount: autoAmount, deadline: deadline)
+    }
+
+    private func deposit(_ goal: GoalModel, _ amount: Double, daysAgo: Int) -> DepositModel {
+        DepositModel(goalID: goal.id, amount: amount,
+                     date: calendar.date(byAdding: .day, value: -daysAgo, to: now) ?? now, source: .manual)
+    }
+
+    // MARK: - Required pace
+
+    func testRequiredWeeklyIsRemainingOverWeeksToDeadline() {
+        let g = goal(target: 1000, current: 200, weeksToDeadline: 8)
+        let pace = GoalPace.compute(goal: g, deposits: [], now: now, calendar: calendar)
+        XCTAssertEqual(pace.requiredWeekly ?? -1, 100, accuracy: 0.001)
+    }
+
+    func testNoDeadlineMeansNoRequiredPaceAndOnTrack() {
+        let g = goal(target: 1000)
+        let pace = GoalPace.compute(goal: g, deposits: [], now: now, calendar: calendar)
+        XCTAssertNil(pace.requiredWeekly)
+        XCTAssertEqual(pace.status, .onTrack)
+    }
+
+    func testDeadlineThisWeekStillYieldsAFinitePace() {
+        XCTAssertEqual(GoalPace.weeksUntil(now.addingTimeInterval(3600), from: now, calendar: calendar), 1)
+    }
+
+    // MARK: - Actual pace
+
+    func testActualPaceAveragesLastFourWeeksOfDeposits() {
+        let g = goal(target: 1000)
+        let deposits = [deposit(g, 100, daysAgo: 3), deposit(g, 100, daysAgo: 20), deposit(g, 999, daysAgo: 40)]
+        let pace = GoalPace.compute(goal: g, deposits: deposits, now: now, calendar: calendar)
+        XCTAssertEqual(pace.actualWeekly, 50, accuracy: 0.001) // 200 over 4 weeks; the 40-day-old one is outside
+    }
+
+    func testActualPaceIgnoresOtherGoalsDeposits() {
+        let g = goal(target: 1000); let other = goal(target: 500)
+        let pace = GoalPace.compute(goal: g, deposits: [deposit(other, 400, daysAgo: 1)], now: now, calendar: calendar)
+        XCTAssertEqual(pace.actualWeekly, 0)
+    }
+
+    func testNoDepositsEverFallsBackToConfiguredAutoMove() {
+        let g = goal(target: 1000, autoMove: true, autoAmount: 433)
+        let pace = GoalPace.compute(goal: g, deposits: [], now: now, calendar: calendar)
+        XCTAssertEqual(pace.actualWeekly, 100, accuracy: 0.01) // 433 / 4.33
+    }
+
+    func testNoDepositsAndNoAutoMoveIsZeroPace() {
+        let pace = GoalPace.compute(goal: goal(target: 1000), deposits: [], now: now, calendar: calendar)
+        XCTAssertEqual(pace.actualWeekly, 0)
+        XCTAssertNil(pace.etaWeeks)
+        XCTAssertEqual(pace.etaText(from: now, calendar: calendar), "—")
+    }
+
+    // MARK: - Status
+
+    func testBehindWhenActualIsBelowRequired() {
+        let g = goal(target: 1000, weeksToDeadline: 8)               // needs 125/wk
+        let pace = GoalPace.compute(goal: g, deposits: [deposit(g, 100, daysAgo: 2)], now: now, calendar: calendar) // 25/wk
+        XCTAssertEqual(pace.status, .behind)
+    }
+
+    func testOnTrackWhenActualMeetsRequired() {
+        let g = goal(target: 1000, weeksToDeadline: 8)               // 125/wk
+        let pace = GoalPace.compute(goal: g, deposits: [deposit(g, 600, daysAgo: 2)], now: now, calendar: calendar) // 150/wk
+        XCTAssertEqual(pace.status, .onTrack)
+    }
+
+    func testCompleteWhenFunded() {
+        let pace = GoalPace.compute(goal: goal(target: 500, current: 500), deposits: [], now: now, calendar: calendar)
+        XCTAssertEqual(pace.status, .complete)
+        XCTAssertEqual(pace.label, "Complete!")
+        XCTAssertEqual(pace.etaText(from: now, calendar: calendar), "Done!")
+    }
+
+    // MARK: - ETA
+
+    func testEtaIsRemainingOverActualPace() {
+        let g = goal(target: 1000, current: 600)                    // 400 left
+        let pace = GoalPace.compute(goal: g, deposits: [deposit(g, 400, daysAgo: 1)], now: now, calendar: calendar) // 100/wk
+        XCTAssertEqual(pace.etaWeeks ?? -1, 4, accuracy: 0.001)
+        let expected = calendar.date(byAdding: .day, value: 28, to: now)
+        let f = DateFormatter(); f.dateFormat = "MMM d"
+        XCTAssertEqual(pace.etaText(from: now, calendar: calendar), f.string(from: try XCTUnwrap(expected)))
+    }
+
+    func testEtaBeyondAYearIsCappedNotFaked() {
+        let g = goal(target: 100_000)
+        let pace = GoalPace.compute(goal: g, deposits: [deposit(g, 40, daysAgo: 1)], now: now, calendar: calendar) // 10/wk
+        XCTAssertEqual(pace.etaText(from: now, calendar: calendar), "1+ year")
+    }
+}


### PR DESCRIPTION
## Summary
Executes `docs/plans/pr-c-goals-complete.md`, in its four commit boundaries:

**1 · Deposit ledger** (`a2c8150`) — `DepositModel` (id, goalID, amount, date, note, source `manual|auto-move`), additive. `GoalDeposits.record(...)` is now the **only** way money enters a goal: same clamp as before, inserts the ledger row (amount = intent, note trimmed / nil), saves with do/catch, throws on ≤ 0. All four writers migrated (goal detail card, dashboard sheet, quick-deposit sheet, payday auto-move — `AutoMoveSuggestion.apply()` deleted; a failed move after the income saved keeps the income and says so). NOTE fields finally persist. `AutoMoveSuggestion.compute` gains `monthDepositTotal` (margin = incomes + this income − expenses − deposits this month), fed from a `@Query` in the income sheet. Goal detail gets a History section with an AUTO tag. Both quick sheets gain the `.alert` their VMs had state for.

**2 · Edit sheet** (`6f026a6`) — `GoalEditSheet` behind both dead pencils (goal detail toolbar, dashboard hero card): name, target, **all 13** colors, target date on/off, auto-move on/off + amount. `GoalEditValidation` is a pure, tested rule set (name, target > 0, target ≥ saved, future deadline only when on, auto amount > 0 only when on). Star is a toggle now.

**3 · Real pace / ETA / completion** (`2c76cea`) — `GoalPace` is the one implementation of the pace policy: required = remaining ÷ weeks-to-deadline (AutoMoveSuggestion calls the same function now); actual = 4-week deposit average, falling back to the configured auto-move for a goal with no deposits ever; on track ⇔ complete / no deadline / actual ≥ required, else **Behind** (clay); ETA = remaining ÷ actual as a date, "1+ year" past 52 weeks, "—" at zero pace — never faked. Goal detail: status line under the ring (deadline finally shown), pills Remaining · Needed/wk · ETA. Dashboard PACE and Goals list read the policy. Goals at 100% move to a **Completed** section (out of the active count) with a one-time pop (mirrors AchievementRow/AchievementStore, instant under Reduce Motion).

**4 · Wizard traps** (`d128a6c`) — "No date" is real (`AddGoalState.hasDeadline`; calendar Date stays non-optional so `MiniCalendarView` is untouched; persists `deadline: nil`, `autoMoveAmount: 0`; Step 3/4 say "—"/"No date"); "Plant goal" disabled until valid instead of a silent no-op, save is do/catch with rollback; success-screen "Add a deposit" presents `DepositSheet` for the goal just created; Step 4 Skip removed; emoji picker + Reminders recap row removed (collected, never persisted) — emoji renders become the name initial on the goal color; two `Toggle("")` get labels.

## Test plan
- [x] `xcodebuild build` — BUILD SUCCEEDED
- [x] `xcodebuild test -skip-testing:SavelyUITests` — TEST SUCCEEDED. New: `GoalDepositsTests` (6, incl. the two migrated `apply` tests), `GoalEditValidationTests` (7), `GoalPaceTests` (12), `AutoMoveSuggestionTests.testMonthDepositsReduceTheMargin`.
- [x] `swiftlint lint --strict` — 0
- [x] **In-place upgrade verified, no store reset:** built `dev` in a worktree, installed, seeded a goal ($278 / $5,000, auto-move 277) + a categorized expense into the pre-C store via SQLite, installed this build over it, launched — `ZDEPOSITMODEL` created (`ZAMOUNT ZDATE ZNOTE ZSOURCE ZGOALID ZID`), goal and expense rows intact, ledger empty. Dump below.
- [ ] **Simulator UI walk NOT done by me** (Claude Code simulator panel is down for this session; no taps). Please run the plan's acceptance path: create goal with and without date → edit it (name/target/color/deadline/auto-move; try target < saved → clear message) → deposit with a note from all three flows → history shows all with the AUTO tag after an armed auto-move income → PACE/ETA react to deadline changes → complete a goal → pop once, listed under Completed → second income same month sees a margin reduced by the first deposit.
- [x] Test data uninstalled

```
=== entities after upgrade ===
1|DepositModel  2|ExpenseModel  3|GoalModel  4|IncomeModel  5|TipModel
=== ZDEPOSITMODEL columns ===
Z_PK Z_ENT Z_OPT ZAMOUNT ZDATE ZNOTE ZSOURCE ZGOALID ZID
ZNAME|ZCURRENT|ZTARGET|ZAUTOMOVEAMOUNT
Legacy trip|278.0|5000.0|277.0
ZEXPENSEDESCRIPTION|ZCATEGORY
Zara|Shopping
deposits: 0
```

## Risks
- New entity (additive) — verified above.
- Behavior: goals with a past deadline are no longer "on track" by default; a goal with a deadline and no deposits/auto-move reads **Behind** — honest, but visible.
- `WarmGoalCard` and `HeroGoalCard` each run a `@Query` filtered by goal ID (one per row). Fine at Savely's goal counts; flagging in case the list ever grows large.
- `AutoMoveSuggestion.apply()` is gone; anything outside this repo calling it would break (nothing does).

## Checklist
- [x] `feat/` branch, Conventional Commits, no AI attribution
- [x] New user-facing strings are literals per the plan's string policy
- [x] No secrets staged
- [x] Tests added