### PR TITLE
fix: scan shortcut opens the scanner; tap outside dismisses the keyboard

### DIFF
--- a/Savely.xcodeproj/project.pbxproj
+++ b/Savely.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		A11A0016C0DE5AFE10000016 /* GoalEditSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A0015C0DE5AFE10000015 /* GoalEditSheet.swift */; };
 		A11A0018C0DE5AFE10000018 /* GoalEditValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A0017C0DE5AFE10000017 /* GoalEditValidation.swift */; };
 		A11A001CC0DE5AFE1000001C /* GoalPace.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A001BC0DE5AFE1000001B /* GoalPace.swift */; };
+		A11A0024C0DE5AFE10000024 /* KeyboardDismisser.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A0023C0DE5AFE10000023 /* KeyboardDismisser.swift */; };
 		A11A0008C0DE5AFE10000008 /* ReminderSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A0007C0DE5AFE10000007 /* ReminderSettingsTests.swift */; };
 		A11A000EC0DE5AFE1000000E /* CategoryPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A000DC0DE5AFE1000000D /* CategoryPersistenceTests.swift */; };
 		A11A0014C0DE5AFE10000014 /* GoalDepositsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A0013C0DE5AFE10000013 /* GoalDepositsTests.swift */; };
@@ -118,6 +119,7 @@
 		A11A0015C0DE5AFE10000015 /* GoalEditSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalEditSheet.swift; sourceTree = "<group>"; };
 		A11A0017C0DE5AFE10000017 /* GoalEditValidation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalEditValidation.swift; sourceTree = "<group>"; };
 		A11A001BC0DE5AFE1000001B /* GoalPace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalPace.swift; sourceTree = "<group>"; };
+		A11A0023C0DE5AFE10000023 /* KeyboardDismisser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardDismisser.swift; sourceTree = "<group>"; };
 		A11A0007C0DE5AFE10000007 /* ReminderSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderSettingsTests.swift; sourceTree = "<group>"; };
 		A11A000DC0DE5AFE1000000D /* CategoryPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryPersistenceTests.swift; sourceTree = "<group>"; };
 		A11A0013C0DE5AFE10000013 /* GoalDepositsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalDepositsTests.swift; sourceTree = "<group>"; };
@@ -275,6 +277,7 @@
 				A11A0011C0DE5AFE10000011 /* GoalDeposits.swift */,
 				A11A0017C0DE5AFE10000017 /* GoalEditValidation.swift */,
 				A11A001BC0DE5AFE1000001B /* GoalPace.swift */,
+				A11A0023C0DE5AFE10000023 /* KeyboardDismisser.swift */,
 				12789AD27FF1A7114156F945 /* AchievementEngine.swift */,
 				693B815A380D566280140319 /* FeatureFlags.swift */,
 				1DE9FE162D066EE20069AA64 /* ReportsPDFGenerator.swift */,
@@ -711,6 +714,7 @@
 				A11A0016C0DE5AFE10000016 /* GoalEditSheet.swift in Sources */,
 				A11A0018C0DE5AFE10000018 /* GoalEditValidation.swift in Sources */,
 				A11A001CC0DE5AFE1000001C /* GoalPace.swift in Sources */,
+				A11A0024C0DE5AFE10000024 /* KeyboardDismisser.swift in Sources */,
 				F764EBD092BA4435466DD9AA /* AchievementEngine.swift in Sources */,
 				ED04D2F84390584EB7EC0615 /* WelcomeStepView.swift in Sources */,
 				699FCB7F699B1E9C9C644AF3 /* SproutMark.swift in Sources */,

--- a/Savely/Managers/CameraManager.swift
+++ b/Savely/Managers/CameraManager.swift
@@ -31,59 +31,81 @@ class CameraManager: NSObject, ObservableObject {
 
     var isProcessingFrame = false
 
+    /// False on devices without a back camera (the simulator) or when the
+    /// user denied camera access — the view shows a message instead of a
+    /// frozen black preview.
+    @Published var isCameraAvailable = true
+    private var isConfigured = false
+
     func startSession() {
-        sessionQueue.async {
-            self.configureSession()
-            self.session.startRunning()
+        AVCaptureDevice.requestAccess(for: .video) { [weak self] granted in
+            guard let self else { return }
+            guard granted else {
+                DispatchQueue.main.async { self.isCameraAvailable = false }
+                return
+            }
+            self.sessionQueue.async {
+                guard self.configureSessionIfNeeded() else { return }
+                if !self.session.isRunning { self.session.startRunning() }
+            }
         }
     }
 
     func stopSession() {
         sessionQueue.async {
-            self.session.stopRunning()
+            if self.session.isRunning { self.session.stopRunning() }
         }
     }
 
-    private func configureSession() {
+    /// Configures the session exactly once. Every exit path commits the
+    /// configuration — `startRunning()` between begin/commit is a crash.
+    /// Returns false when there is nothing to run (no camera).
+    @discardableResult
+    private func configureSessionIfNeeded() -> Bool {
+        if isConfigured { return true }
         session.beginConfiguration()
+        defer { session.commitConfiguration() }
         session.sessionPreset = .photo
 
         guard let videoDevice = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: .back) else {
-            print("No se pudo acceder a la cámara trasera.")
-            return
+            print("No back camera on this device.")
+            DispatchQueue.main.async { self.isCameraAvailable = false }
+            return false
         }
 
         do {
             let videoDeviceInput = try AVCaptureDeviceInput(device: videoDevice)
-            if session.canAddInput(videoDeviceInput) {
-                session.addInput(videoDeviceInput)
-            } else {
-                print("No se pudo agregar entrada de cámara a la sesión.")
-                return
+            guard session.canAddInput(videoDeviceInput) else {
+                print("Could not add the camera input.")
+                DispatchQueue.main.async { self.isCameraAvailable = false }
+                return false
             }
+            session.addInput(videoDeviceInput)
         } catch {
-            print("Error al crear entrada de cámara: \(error)")
-            return
+            print("Could not create the camera input: \(error)")
+            DispatchQueue.main.async { self.isCameraAvailable = false }
+            return false
         }
 
-        if session.canAddOutput(photoOutput) {
-            session.addOutput(photoOutput)
-        } else {
-            print("No se pudo agregar salida de foto a la sesión.")
-            return
+        guard session.canAddOutput(photoOutput) else {
+            print("Could not add the photo output.")
+            DispatchQueue.main.async { self.isCameraAvailable = false }
+            return false
         }
+        session.addOutput(photoOutput)
 
         videoOutput.setSampleBufferDelegate(self, queue: DispatchQueue(label: "video_output_queue"))
-        if session.canAddOutput(videoOutput) {
-            session.addOutput(videoOutput)
-            videoOutput.alwaysDiscardsLateVideoFrames = true
-            videoOutput.videoSettings = [kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA]
-        } else {
-            print("No se pudo agregar salida de video a la sesión.")
-            return
+        guard session.canAddOutput(videoOutput) else {
+            print("Could not add the video output.")
+            DispatchQueue.main.async { self.isCameraAvailable = false }
+            return false
         }
+        session.addOutput(videoOutput)
+        videoOutput.alwaysDiscardsLateVideoFrames = true
+        videoOutput.videoSettings = [kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA]
 
-        session.commitConfiguration()
+        isConfigured = true
+        return true
     }
 
     func setPreviewLayer(to view: UIView) {
@@ -92,6 +114,12 @@ class CameraManager: NSObject, ObservableObject {
         layer.frame = view.bounds
         previewLayer = layer
         view.layer.insertSublayer(layer, at: 0)
+    }
+
+    /// Keeps the preview filling the view when it is laid out (sheet vs
+    /// full-screen, rotation).
+    func layoutPreviewLayer(in view: UIView) {
+        previewLayer?.frame = view.bounds
     }
 
     func capturePhoto() {

--- a/Savely/Resources/Localizable.xcstrings
+++ b/Savely/Resources/Localizable.xcstrings
@@ -10,6 +10,44 @@
     " of %lld" : {
 
     },
+    "—" : {
+
+    },
+    ", favorite" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ", favorite"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ", favorita"
+          }
+        }
+      }
+    },
+    ".00" : {
+
+    },
+    "/wk" : {
+
+    },
+    "%" : {
+
+    },
+    "%@ · %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ · %2$@"
+          }
+        }
+      }
+    },
     "%@ %lld percent" : {
       "localizations" : {
         "en" : {
@@ -42,21 +80,8 @@
         }
       }
     },
-    "%@%@, %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@%@, %@"
-          }
-        },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@%2$@, %3$@"
-          }
-        }
-      }
+    "%@ is on your home screen.\nAdd the first dollar?" : {
+
     },
     "%@, %@" : {
       "localizations" : {
@@ -90,446 +115,31 @@
         }
       }
     },
-    "%lld percent, %@ of %@" : {
+    "%@, %@%@" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "%lld percent, %@ of %@"
+            "value" : "%1$@, %2$@%3$@"
+          }
+        }
+      }
+    },
+    "%@%@, %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@%@, %@"
           }
         },
         "es-419" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$lld por ciento, %2$@ de %3$@"
+            "value" : "%1$@%2$@, %3$@"
           }
         }
       }
-    },
-    ", favorite" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ", favorite"
-          }
-        },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : ", favorita"
-          }
-        }
-      }
-    },
-    "Add" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add"
-          }
-        },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Agregar"
-          }
-        }
-      }
-    },
-    "Add expense" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add expense"
-          }
-        },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Agregar gasto"
-          }
-        }
-      }
-    },
-    "Add income" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add income"
-          }
-        },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Agregar ingreso"
-          }
-        }
-      }
-    },
-    "Back" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Back"
-          }
-        },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Atrás"
-          }
-        }
-      }
-    },
-    "Clear name" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Clear name"
-          }
-        },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Borrar nombre"
-          }
-        }
-      }
-    },
-    "Close" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close"
-          }
-        },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cerrar"
-          }
-        }
-      }
-    },
-    "Decimal point" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Decimal point"
-          }
-        },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Punto decimal"
-          }
-        }
-      }
-    },
-    "Expense" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Expense"
-          }
-        },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gasto"
-          }
-        }
-      }
-    },
-    "Expense amount" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Expense amount"
-          }
-        },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Monto del gasto"
-          }
-        }
-      }
-    },
-    "Income amount" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Income amount"
-          }
-        },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Monto del ingreso"
-          }
-        }
-      }
-    },
-    "Log an expense, income, deposit, or new goal" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Log an expense, income, deposit, or new goal"
-          }
-        },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Registra un gasto, un ingreso, un depósito o una meta nueva"
-          }
-        }
-      }
-    },
-    "Long press to delete" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Long press to delete"
-          }
-        },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mantén presionado para eliminar"
-          }
-        }
-      }
-    },
-    "Make favorite" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Make favorite"
-          }
-        },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Marcar como favorita"
-          }
-        }
-      }
-    },
-    "Month over month" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Month over month"
-          }
-        },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mes contra mes"
-          }
-        }
-      }
-    },
-    "New goal" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New goal"
-          }
-        },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nueva meta"
-          }
-        }
-      }
-    },
-    "Next month" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Next month"
-          }
-        },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mes siguiente"
-          }
-        }
-      }
-    },
-    "Previous month" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Previous month"
-          }
-        },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mes anterior"
-          }
-        }
-      }
-    },
-    "Progress" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Progress"
-          }
-        },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Progreso"
-          }
-        }
-      }
-    },
-    "Remove from favorites" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Remove from favorites"
-          }
-        },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quitar de favoritas"
-          }
-        }
-      }
-    },
-    "Unlocked" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Unlocked"
-          }
-        },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desbloqueado"
-          }
-        }
-      }
-    },
-    "down" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "down"
-          }
-        },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "abajo"
-          }
-        }
-      }
-    },
-    "minus %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "minus %@"
-          }
-        },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "menos %@"
-          }
-        }
-      }
-    },
-    "plus %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "plus %@"
-          }
-        },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "más %@"
-          }
-        }
-      }
-    },
-    "up" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "up"
-          }
-        },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "arriba"
-          }
-        }
-      }
-    },
-    "—" : {
-
-    },
-    ".00" : {
-
-    },
-    "/wk" : {
-
-    },
-    "%" : {
-
-    },
-    "%@ · %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ · %2$@"
-          }
-        }
-      }
-    },
-    "%@ is on your home screen.\nAdd the first dollar?" : {
-
     },
     "%lld" : {
 
@@ -554,16 +164,32 @@
         }
       }
     },
-      "%lld percent" : {
-        "localizations" : {
-          "es-419" : {
-            "stringUnit" : {
-              "state" : "translated",
-              "value" : "%lld por ciento"
-            }
+    "%lld percent" : {
+      "localizations" : {
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld por ciento"
           }
         }
-      },
+      }
+    },
+    "%lld percent, %@ of %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%lld percent, %@ of %@"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld por ciento, %2$@ de %3$@"
+          }
+        }
+      }
+    },
     "%lld%%" : {
 
     },
@@ -650,6 +276,22 @@
         }
       }
     },
+    "Add" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Add"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agregar"
+          }
+        }
+      }
+    },
     "Add %@ to %@" : {
       "localizations" : {
         "en" : {
@@ -685,6 +327,38 @@
     },
     "Add deposit" : {
 
+    },
+    "Add expense" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Add expense"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agregar gasto"
+          }
+        }
+      }
+    },
+    "Add income" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Add income"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agregar ingreso"
+          }
+        }
+      }
     },
     "Add your first expense above" : {
 
@@ -836,6 +510,22 @@
     "Auto-move on payday" : {
 
     },
+    "Back" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Back"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atrás"
+          }
+        }
+      }
+    },
     "Back to home" : {
 
     },
@@ -923,6 +613,38 @@
         }
       }
     },
+    "Clear name" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Clear name"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Borrar nombre"
+          }
+        }
+      }
+    },
+    "Close" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Close"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cerrar"
+          }
+        }
+      }
+    },
     "COLOR" : {
 
     },
@@ -944,16 +666,16 @@
         }
       }
     },
-      "Completed" : {
-        "localizations" : {
-          "es-419" : {
-            "stringUnit" : {
-              "state" : "translated",
-              "value" : "Completadas"
-            }
+    "Completed" : {
+      "localizations" : {
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Completadas"
           }
         }
-      },
+      }
+    },
     "confirm_password_string" : {
       "comment" : "Confirm Password String",
       "extractionState" : "stale",
@@ -1203,16 +925,32 @@
         }
       }
     },
-      "Delete" : {
-        "localizations" : {
-          "es-419" : {
-            "stringUnit" : {
-              "state" : "translated",
-              "value" : "Eliminar"
-            }
+    "Decimal point" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Decimal point"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Punto decimal"
           }
         }
-      },
+      }
+    },
+    "Delete" : {
+      "localizations" : {
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar"
+          }
+        }
+      }
+    },
     "Delete Expense" : {
 
     },
@@ -1348,6 +1086,22 @@
         }
       }
     },
+    "down" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "down"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "abajo"
+          }
+        }
+      }
+    },
     "download_weekly_report_button" : {
       "comment" : "Download Weekly Report Button",
       "extractionState" : "extracted_with_value",
@@ -1372,16 +1126,16 @@
     "Edit anything" : {
 
     },
-      "Edit goal" : {
-        "localizations" : {
-          "es-419" : {
-            "stringUnit" : {
-              "state" : "translated",
-              "value" : "Editar meta"
-            }
+    "Edit goal" : {
+      "localizations" : {
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Editar meta"
           }
         }
-      },
+      }
+    },
     "email_placeholder_title" : {
       "comment" : "Email Placeholder Label",
       "extractionState" : "extracted_with_value",
@@ -1486,6 +1240,38 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Error"
+          }
+        }
+      }
+    },
+    "Expense" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Expense"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gasto"
+          }
+        }
+      }
+    },
+    "Expense amount" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Expense amount"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Monto del gasto"
           }
         }
       }
@@ -1964,29 +1750,45 @@
         }
       }
     },
-      "History" : {
-        "localizations" : {
-          "es-419" : {
-            "stringUnit" : {
-              "state" : "translated",
-              "value" : "Historial"
-            }
+    "History" : {
+      "localizations" : {
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Historial"
           }
         }
-      },
+      }
+    },
     "HOW MUCH" : {
 
     },
-      "Income" : {
-        "localizations" : {
-          "es-419" : {
-            "stringUnit" : {
-              "state" : "translated",
-              "value" : "Ingreso"
-            }
+    "Income" : {
+      "localizations" : {
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ingreso"
           }
         }
-      },
+      }
+    },
+    "Income amount" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Income amount"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Monto del ingreso"
+          }
+        }
+      }
+    },
     "income_distribution_label" : {
       "comment" : "Income Distribution Label",
       "extractionState" : "extracted_with_value",
@@ -2101,6 +1903,22 @@
         }
       }
     },
+    "Log an expense, income, deposit, or new goal" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Log an expense, income, deposit, or new goal"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Registra un gasto, un ingreso, un depósito o una meta nueva"
+          }
+        }
+      }
+    },
     "Log expense" : {
 
     },
@@ -2125,8 +1943,72 @@
         }
       }
     },
+    "Long press to delete" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Long press to delete"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mantén presionado para eliminar"
+          }
+        }
+      }
+    },
+    "Make favorite" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Make favorite"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Marcar como favorita"
+          }
+        }
+      }
+    },
     "Merchant · Today" : {
 
+    },
+    "minus %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "minus %@"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "menos %@"
+          }
+        }
+      }
+    },
+    "Month over month" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Month over month"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mes contra mes"
+          }
+        }
+      }
     },
     "monthly_goal_label" : {
       "comment" : "Monthly Goal Label",
@@ -2212,8 +2094,40 @@
     "New" : {
 
     },
+    "New goal" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "New goal"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nueva meta"
+          }
+        }
+      }
+    },
     "New goal · " : {
 
+    },
+    "Next month" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Next month"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mes siguiente"
+          }
+        }
+      }
     },
     "next_achievement_label" : {
       "comment" : "Kicker above the closest locked achievement",
@@ -2695,6 +2609,38 @@
         }
       }
     },
+    "plus %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "plus %@"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "más %@"
+          }
+        }
+      }
+    },
+    "Previous month" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Previous month"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mes anterior"
+          }
+        }
+      }
+    },
     "previous_tips_title" : {
       "comment" : "Previous Tips",
       "extractionState" : "extracted_with_value",
@@ -2727,6 +2673,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Perfil"
+          }
+        }
+      }
+    },
+    "Progress" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Progress"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Progreso"
           }
         }
       }
@@ -2841,6 +2803,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hora"
+          }
+        }
+      }
+    },
+    "Remove from favorites" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Remove from favorites"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quitar de favoritas"
           }
         }
       }
@@ -3697,6 +3675,38 @@
     },
     "UNDO" : {
 
+    },
+    "Unlocked" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unlocked"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desbloqueado"
+          }
+        }
+      }
+    },
+    "up" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "up"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "arriba"
+          }
+        }
+      }
     },
     "update_information_button" : {
       "comment" : "Update Information Button",

--- a/Savely/Resources/Localizable.xcstrings
+++ b/Savely/Resources/Localizable.xcstrings
@@ -435,6 +435,9 @@
         }
       }
     },
+    "Allow camera access in Settings, or use a device with a camera." : {
+
+    },
     "ALMOST THERE" : {
 
     },
@@ -549,6 +552,9 @@
           }
         }
       }
+    },
+    "Camera not available" : {
+
     },
     "Can't save yet" : {
 

--- a/Savely/SavelyApp.swift
+++ b/Savely/SavelyApp.swift
@@ -22,6 +22,7 @@ struct SavelyApp: App {
                 .honorsReduceMotion()
                 .onAppear {
                     NotificationManager.shared.requestAuthorization()
+                    KeyboardDismisser.install()
                 }
         }
         .modelContainer(for: [TipModel.self, IncomeModel.self, ExpenseModel.self, GoalModel.self, DepositModel.self])

--- a/Savely/Utilities/KeyboardDismisser.swift
+++ b/Savely/Utilities/KeyboardDismisser.swift
@@ -1,0 +1,58 @@
+//
+//  KeyboardDismisser.swift
+//  Savely
+//
+//  Tap anywhere outside a text field to put the keyboard away. Installed
+//  once on the key window rather than per screen so every form, sheet and
+//  wizard step gets it — including ones added later.
+//
+
+import UIKit
+
+enum KeyboardDismisser {
+    private static var installed = false
+
+    /// Call from the root view's onAppear. If the window is not up yet
+    /// (first frame), retries shortly — it must never silently give up.
+    static func install() {
+        guard !installed else { return }
+        let windows = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .flatMap(\.windows)
+        guard let window = windows.first(where: \.isKeyWindow) ?? windows.first else {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { install() }
+            return
+        }
+        let tap = UITapGestureRecognizer(target: Handler.shared, action: #selector(Handler.dismiss))
+        // Let the tap reach whatever was tapped (buttons, rows, another
+        // field) — we only piggyback on it to resign the keyboard.
+        tap.cancelsTouchesInView = false
+        tap.delegate = Handler.shared
+        window.addGestureRecognizer(tap)
+        installed = true
+    }
+
+    private final class Handler: NSObject, UIGestureRecognizerDelegate {
+        static let shared = Handler()
+
+        @objc func dismiss() {
+            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+        }
+
+        /// Don't fire for taps *inside* an editable control — those should
+        /// place the caret, not close the keyboard.
+        func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+            var view = touch.view
+            while let current = view {
+                if current is UITextField || current is UITextView { return false }
+                view = current.superview
+            }
+            return true
+        }
+
+        func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer,
+                               shouldRecognizeSimultaneouslyWith other: UIGestureRecognizer) -> Bool {
+            true
+        }
+    }
+}

--- a/Savely/ViewModels/Camera/CameraViewModel.swift
+++ b/Savely/ViewModels/Camera/CameraViewModel.swift
@@ -10,7 +10,7 @@ import SwiftUI
 import Vision
 import Combine
 
-class CameraViewModel: ObservableObject {
+class CameraViewModel: ObservableObject, Identifiable {
     @Published var showConfirmation = false
     @Published var detectedTotal: String = ""
     @Published var alternativeTotals: [String] = []

--- a/Savely/ViewModels/Camera/CameraViewModel.swift
+++ b/Savely/ViewModels/Camera/CameraViewModel.swift
@@ -16,6 +16,7 @@ class CameraViewModel: ObservableObject, Identifiable {
     @Published var alternativeTotals: [String] = []
     @Published var isRectangleDetected: Bool = false
     @Published var detectedRectangle: VNRectangleObservation?
+    @Published var isCameraAvailable: Bool = true
 
     private let textRecognizer = TextRecognizer()
     private var cancellables = Set<AnyCancellable>()
@@ -48,6 +49,11 @@ class CameraViewModel: ObservableObject, Identifiable {
         cameraManager.$detectedRectangle
             .receive(on: RunLoop.main)
             .assign(to: \.detectedRectangle, on: self)
+            .store(in: &cancellables)
+
+        cameraManager.$isCameraAvailable
+            .receive(on: RunLoop.main)
+            .assign(to: \.isCameraAvailable, on: self)
             .store(in: &cancellables)
     }
 

--- a/Savely/Views/Components/CameraScanner/CameraPreview.swift
+++ b/Savely/Views/Components/CameraScanner/CameraPreview.swift
@@ -11,13 +11,27 @@ import AVFoundation
 struct CameraPreview: UIViewRepresentable {
     let cameraManager: CameraManager
 
-    func makeUIView(context: Context) -> UIView {
-        let view = UIView(frame: UIScreen.main.bounds)
+    func makeUIView(context: Context) -> PreviewHostView {
+        let view = PreviewHostView()
+        view.backgroundColor = .black
         cameraManager.setPreviewLayer(to: view)
+        view.onLayout = { [weak view] in
+            guard let view else { return }
+            cameraManager.layoutPreviewLayer(in: view)
+        }
         return view
     }
 
-    func updateUIView(_ uiView: UIView, context: Context) {
-        // No es necesario actualizar nada aquí por ahora
+    func updateUIView(_ uiView: PreviewHostView, context: Context) {}
+
+    /// A plain view that tells the preview layer when its bounds change —
+    /// UIScreen.main.bounds at creation time is wrong for a sheet and for
+    /// rotation.
+    final class PreviewHostView: UIView {
+        var onLayout: (() -> Void)?
+        override func layoutSubviews() {
+            super.layoutSubviews()
+            onLayout?()
+        }
     }
 }

--- a/Savely/Views/Components/CameraScanner/CameraView.swift
+++ b/Savely/Views/Components/CameraScanner/CameraView.swift
@@ -17,6 +17,29 @@ struct CameraView: View {
         ZStack {
             CameraPreview(cameraManager: viewModel.cameraManager)
                 .edgesIgnoringSafeArea(.all)
+
+            // No back camera (simulator) or access denied — say so instead of
+            // leaving a frozen black preview.
+            if !viewModel.isCameraAvailable {
+                VStack(spacing: 10) {
+                    Image(systemName: "camera.badge.ellipsis")
+                        .warmFont(36)
+                        .foregroundStyle(.white.opacity(0.85))
+                    Text("Camera not available")
+                        .warmFont(17, weight: .semibold)
+                        .foregroundStyle(.white)
+                    Text("Allow camera access in Settings, or use a device with a camera.")
+                        .warmFont(13)
+                        .foregroundStyle(.white.opacity(0.75))
+                        .multilineTextAlignment(.center)
+                }
+                .padding(24)
+                .frame(maxWidth: 300)
+                .background(Color.black.opacity(0.55))
+                .cornerRadius(20)
+                .accessibilityElement(children: .combine)
+            }
+
             VStack {
                 HStack {
                     Button(action: {

--- a/Savely/Views/ExpensesTab/ExpenseTrackerView.swift
+++ b/Savely/Views/ExpensesTab/ExpenseTrackerView.swift
@@ -78,7 +78,9 @@ struct ExpenseTrackerView: View {
                     .background(Color.warmInk)
                     .cornerRadius(20)
                 }
-                .sheet(isPresented: $showCameraView) {
+                // Full screen, same as the "+" shortcut — the scanner is a
+                // camera, not a form.
+                .fullScreenCover(isPresented: $showCameraView) {
                     let cameraViewModel = CameraViewModel(expenseViewModel: viewModel)
                     CameraView(viewModel: cameraViewModel)
                 }

--- a/Savely/Views/MainNavigationView.swift
+++ b/Savely/Views/MainNavigationView.swift
@@ -14,6 +14,12 @@ struct MainNavigationView: View {
     @State private var showActionSheet = false
     @State private var quickScreen: QuickAddScreen = .actionSheet
     @State private var showAddGoalFlow = false
+    @Environment(\.modelContext) private var modelContext
+    /// The receipt scanner presented from the "+" sheet. It writes through
+    /// its own expense view model, exactly like the Money tab's banner does;
+    /// the Money tab hears about the new row through the posted notification.
+    @StateObject private var scanExpenseVM = ExpenseTrackerViewModel()
+    @State private var scanner: CameraViewModel?
 
     var body: some View {
         ZStack(alignment: .bottom) {
@@ -45,6 +51,13 @@ struct MainNavigationView: View {
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
                         showAddGoalFlow = true
                     }
+                },
+                onScan: {
+                    showActionSheet = false
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
+                        scanExpenseVM.setModelContext(modelContext)
+                        scanner = CameraViewModel(expenseViewModel: scanExpenseVM)
+                    }
                 }
             )
             .honorsReduceMotion()
@@ -56,6 +69,9 @@ struct MainNavigationView: View {
         .fullScreenCover(isPresented: $showAddGoalFlow) {
             AddGoalFlowView(isPresented: $showAddGoalFlow)
                 .honorsReduceMotion()
+        }
+        .fullScreenCover(item: $scanner) { vm in
+            CameraView(viewModel: vm)
         }
     }
 }
@@ -140,6 +156,7 @@ struct WarmQuickAddContainer: View {
     @Binding var screen: QuickAddScreen
     let onDismiss: () -> Void
     let onNewGoal: () -> Void
+    let onScan: () -> Void
 
     var body: some View {
         Group {
@@ -148,7 +165,8 @@ struct WarmQuickAddContainer: View {
                 WarmActionSheet(
                     onSelect: { s in withAnimation(.spring(response: 0.32, dampingFraction: 0.82)) { screen = s } },
                     onDismiss: onDismiss,
-                    onNewGoal: onNewGoal
+                    onNewGoal: onNewGoal,
+                    onScan: onScan
                 )
             case .expense:
                 WarmQuickExpenseView(
@@ -174,23 +192,25 @@ struct WarmQuickAddContainer: View {
 // MARK: - Action sheet
 
 private struct QuickAction {
+    enum Kind { case screen(QuickAddScreen), newGoal, scan }
     let icon: String; let label: String; let sub: String
-    let bg: Color; let fg: Color; let target: QuickAddScreen?; let isNewGoal: Bool
+    let bg: Color; let fg: Color; let kind: Kind
 }
 
 private let quickActions: [QuickAction] = [
-    QuickAction(icon: "wallet.pass",  label: "Log expense",       sub: "Coffee, groceries, anything",  bg: .warmAmberSoft, fg: .warmAmber, target: .expense,  isNewGoal: false),
-    QuickAction(icon: "arrow.up",     label: "Log income",        sub: "Paycheck, gift, side work",    bg: .warmGreenSoft, fg: .warmGreen, target: .income,   isNewGoal: false),
-    QuickAction(icon: "target",       label: "Deposit to a goal", sub: "Move money toward a goal",     bg: .warmSkySoft,   fg: .warmSky,   target: .deposit,  isNewGoal: false),
-    QuickAction(icon: "camera",       label: "Scan a receipt",    sub: "We'll read the total",          bg: .warmClaySoft,  fg: .warmClay,  target: .expense,  isNewGoal: false),
+    QuickAction(icon: "wallet.pass",  label: "Log expense",       sub: "Coffee, groceries, anything",  bg: .warmAmberSoft, fg: .warmAmber, kind: .screen(.expense)),
+    QuickAction(icon: "arrow.up",     label: "Log income",        sub: "Paycheck, gift, side work",    bg: .warmGreenSoft, fg: .warmGreen, kind: .screen(.income)),
+    QuickAction(icon: "target",       label: "Deposit to a goal", sub: "Move money toward a goal",     bg: .warmSkySoft,   fg: .warmSky,   kind: .screen(.deposit)),
+    QuickAction(icon: "camera",       label: "Scan a receipt",    sub: "We'll read the total",          bg: .warmClaySoft,  fg: .warmClay,  kind: .scan),
     QuickAction(icon: "plus",         label: "New goal",          sub: "Start something new",
-                bg: .warmLilacSoft, fg: .warmLilac, target: nil, isNewGoal: true),
+                bg: .warmLilacSoft, fg: .warmLilac, kind: .newGoal),
 ]
 
 struct WarmActionSheet: View {
     let onSelect: (QuickAddScreen) -> Void
     let onDismiss: () -> Void
     let onNewGoal: () -> Void
+    let onScan: () -> Void
 
     var body: some View {
         VStack(spacing: 0) {
@@ -224,8 +244,11 @@ struct WarmActionSheet: View {
             VStack(spacing: 0) {
                 ForEach(Array(quickActions.enumerated()), id: \.offset) { i, action in
                     Button(action: {
-                        if action.isNewGoal { onNewGoal() }
-                        else if let t = action.target { onSelect(t) }
+                        switch action.kind {
+                        case .screen(let target): onSelect(target)
+                        case .newGoal: onNewGoal()
+                        case .scan: onScan()
+                        }
                     }) {
                         HStack(spacing: 14) {
                             Image(systemName: action.icon)


### PR DESCRIPTION
## Summary
- **"+" → Scan a receipt now opens the scanner.** It was wired to `.expense` (the keypad). `QuickAction` gets an explicit `kind` (`.screen(_)` / `.newGoal` / `.scan`); scan dismisses the sheet and presents `CameraView` full-screen with the same 0.35 s hand-off "New goal" uses. It writes through its own `ExpenseTrackerViewModel` (like the Money tab's banner), so the Money list picks the row up via the posted notification. `CameraViewModel` is `Identifiable` for `fullScreenCover(item:)`.
- **Tap outside a field dismisses the keyboard, app-wide.** `KeyboardDismisser` installs one `UITapGestureRecognizer` on the key window (`cancelsTouchesInView = false`, delegate ignores taps inside `UITextField`/`UITextView`) — every form, sheet and wizard step gets it without per-screen wiring. Retries if the window isn't up yet.

## Test plan
- [x] Build, tests, `swiftlint --strict` green
- [ ] Simulator (owner): "+" → Scan a receipt → camera opens full-screen; capture → confirmation → expense saved and visible on Money; close X returns to where you were. Tap outside the inline amount field on Money / the goal edit sheet fields / the wizard name field → keyboard drops; tapping a button while the keyboard is up still triggers the button; tapping inside a field keeps the caret.

## Risks
- The window-level recognizer runs on every tap (cheap) and only sends `resignFirstResponder`; `cancelsTouchesInView = false` keeps buttons working. If any custom text input isn't a UITextField/UITextView underneath, a tap inside it would drop the keyboard — none exist today.
- The scanner itself is unchanged (its accuracy work is the next PR once the ticket fixtures land).